### PR TITLE
Fix build with gcc 5

### DIFF
--- a/lib/hash-algorithms.c
+++ b/lib/hash-algorithms.c
@@ -29,7 +29,7 @@
  * Returns:
  * - the hash key
  */
-inline uint32_t qha_jenkins1(uint32_t key)
+uint32_t qha_jenkins1(uint32_t key)
 {
 	key = (key ^ 61) ^ (key >> 16);
 	key = key + (key << 3);
@@ -50,7 +50,7 @@ inline uint32_t qha_jenkins1(uint32_t key)
  * Returns:
  * - the hash key
  */
-inline uint32_t qha_jenkins2(uint32_t key)
+uint32_t qha_jenkins2(uint32_t key)
 {
 	key = (key+0x7ed55d16) + (key<<12);
 	key = (key^0xc761c23c) ^ (key>>19);
@@ -70,12 +70,12 @@ inline uint32_t qha_jenkins2(uint32_t key)
  * Returns:
  * - the hash key
  */
-inline uint32_t qha_no_hash(uint32_t key)
+uint32_t qha_no_hash(uint32_t key)
 {
 	return key;
 }
 
-inline uint32_t qha_djb2(char *key)
+uint32_t qha_djb2(char *key)
 {
 	uint32_t hash = 5381;
 	int c;
@@ -87,7 +87,7 @@ inline uint32_t qha_djb2(char *key)
 	return hash;
 }
 
-inline uint32_t qha_sdbm(char *key)
+uint32_t qha_sdbm(char *key)
 {
 	uint32_t hash = 0;
 	int c;

--- a/lib/hash-algorithms.h
+++ b/lib/hash-algorithms.h
@@ -21,11 +21,11 @@
 #ifndef QH_HASH_ALGORITHMS_H
 #define QH_HASH_ALGORITHMS_H
 
-inline uint32_t qha_jenkins1(uint32_t key);
-inline uint32_t qha_jenkins2(uint32_t key);
-inline uint32_t qha_no_hash(uint32_t key);
+uint32_t qha_jenkins1(uint32_t key);
+uint32_t qha_jenkins2(uint32_t key);
+uint32_t qha_no_hash(uint32_t key);
 
-inline uint32_t qha_djb2(char *key);
-inline uint32_t qha_sdbm(char *key);
+uint32_t qha_djb2(char *key);
+uint32_t qha_sdbm(char *key);
 
 #endif


### PR DESCRIPTION
See http://www.gnu.org/software/gcc/gcc-5/porting_to.html

Simpler to drop "inline", especially as pointer to these functions are used.

During build:

     In file included from /builddir/build/BUILD/php-pecl-quickhash-1.0.0/ZTS/lib/quickhash.c:25:0:
     /builddir/build/BUILD/php-pecl-quickhash-1.0.0/ZTS/lib/hash-algorithms.h:29:17: warning: inline function 'qha_sdbm' declared but never defined
      inline uint32_t qha_sdbm(char *key);
                      ^
     /builddir/build/BUILD/php-pecl-quickhash-1.0.0/ZTS/lib/hash-algorithms.h:28:17: warning: inline function 'qha_djb2' declared but never defined
      inline uint32_t qha_djb2(char *key);
                      ^
     /builddir/build/BUILD/php-pecl-quickhash-1.0.0/ZTS/lib/hash-algorithms.h:26:17: warning: inline function 'qha_no_hash' declared but never defined
      inline uint32_t qha_no_hash(uint32_t key);
                      ^
     /builddir/build/BUILD/php-pecl-quickhash-1.0.0/ZTS/lib/hash-algorithms.h:25:17: warning: inline function 'qha_jenkins2' declared but never defined
      inline uint32_t qha_jenkins2(uint32_t key);
                      ^
     /builddir/build/BUILD/php-pecl-quickhash-1.0.0/ZTS/lib/hash-algorithms.h:24:17: warning: inline function 'qha_jenkins1' declared but never defined
      inline uint32_t qha_jenkins1(uint32_t key);
                      ^

At runtime:

     PHP Warning:  PHP Startup: Unable to load dynamic library 'modules/quickhash.so' - modules/quickhash.so: undefined symbol: qha_jenkins2 in Unknown on line 0
