### PR TITLE
PHP7 port, with support for PHP5.5+

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -5,7 +5,7 @@ PHP_ARG_ENABLE(quickhash, whether to enable quickhash support,
 [  --enable-quickhash      Enable quickhash support])
 
 if test "$PHP_QUICKHASH" != "no"; then
-  PHP_NEW_EXTENSION(quickhash, quickhash.c qh_inthash.c qh_intset.c qh_intstringhash.c qh_stringinthash.c qh_iterator.c lib/quickhash.c lib/hash-algorithms.c lib/iterator.c, $ext_shared)
+  PHP_NEW_EXTENSION(quickhash, quickhash.c qh_inthash.c qh_intset.c qh_intstringhash.c qh_stringinthash.c qh_iterator.c lib/quickhash.c lib/hash-algorithms.c lib/iterator.c, $ext_shared,,-DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)
   PHP_SUBST(QUICKHASH_SHARED_LIBADD)
   PHP_ADD_BUILD_DIR($ext_builddir/lib, 1)
 fi

--- a/lib/hash-algorithms.h
+++ b/lib/hash-algorithms.h
@@ -16,17 +16,10 @@
    +----------------------------------------------------------------------+
  */
 
-// Added to support uint32_t on linux because it is defined in stdint.h
-#include "php.h"
-#include "zend.h"
-#include "zend_API.h"
-
 #if HAVE_CONFIG_H
 # include <config.h>
 #endif
-#if HAVE_STDINT_H
-# include <stdint.h>
-#endif
+#include <stdint.h>
 #if HAVE_STDLIB_H
 # include <stdlib.h>
 #endif

--- a/lib/hash-algorithms.h
+++ b/lib/hash-algorithms.h
@@ -20,9 +20,7 @@
 # include <config.h>
 #endif
 #include <stdint.h>
-#if HAVE_STDLIB_H
-# include <stdlib.h>
-#endif
+#include <stdlib.h>
 
 #ifndef QH_HASH_ALGORITHMS_H
 #define QH_HASH_ALGORITHMS_H

--- a/lib/hash-algorithms.h
+++ b/lib/hash-algorithms.h
@@ -15,6 +15,12 @@
    | Authors: Derick Rethans <derick@derickrethans.nl>                    |
    +----------------------------------------------------------------------+
  */
+
+// Added to support uint32_t on linux because it is defined in stdint.h
+#include "php.h"
+#include "zend.h"
+#include "zend_API.h"
+
 #if HAVE_CONFIG_H
 # include <config.h>
 #endif

--- a/lib/quickhash.h
+++ b/lib/quickhash.h
@@ -16,17 +16,10 @@
    +----------------------------------------------------------------------+
  */
 
-// Added to support uint32_t on linux because it is defined in stdint.h
-#include "php.h"
-#include "zend.h"
-#include "zend_API.h"
-
 #if HAVE_CONFIG_H
 # include <config.h>
 #endif
-#if HAVE_STDINT_H
-# include <stdint.h>
-#endif
+#include <stdint.h>
 #if HAVE_STDLIB_H
 # include <stdlib.h>
 #endif

--- a/lib/quickhash.h
+++ b/lib/quickhash.h
@@ -20,18 +20,10 @@
 # include <config.h>
 #endif
 #include <stdint.h>
-#if HAVE_STDLIB_H
-# include <stdlib.h>
-#endif
-#if HAVE_SYS_TYPES_H
-# include <sys/types.h>
-#endif
-#if HAVE_SYS_STAT_H
-# include <sys/stat.h>
-#endif
-#if HAVE_STRING_H
-# include <string.h>
-#endif
+#include <stdlib.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <string.h>
 
 #ifndef QUICK_HASH_H
 #define QUICK_HASH_H

--- a/lib/quickhash.h
+++ b/lib/quickhash.h
@@ -15,6 +15,12 @@
    | Authors: Derick Rethans <derick@derickrethans.nl>                    |
    +----------------------------------------------------------------------+
  */
+
+// Added to support uint32_t on linux because it is defined in stdint.h
+#include "php.h"
+#include "zend.h"
+#include "zend_API.h"
+
 #if HAVE_CONFIG_H
 # include <config.h>
 #endif

--- a/package.xml
+++ b/package.xml
@@ -17,10 +17,10 @@ the sets and hashes.
   <email>derick@php.net</email>
   <active>yes</active>
  </lead>
- <date>2016-05-07</date>
- <time>17:40:00</time>
+ <date>2016-05-22</date>
+ <time>09:00:00</time>
  <version>
-  <release>2.0.0</release>
+  <release>1.1.0</release>
   <api>1.0.0</api>
  </version>
  <stability>

--- a/package.xml
+++ b/package.xml
@@ -9,7 +9,7 @@ xsi:schemaLocation="http://pear.php.net/dtd/tasks-1.0 http://pear.php.net/dtd/ta
 hash, integer to string hash and a string to integer hash. The main features
 are low memory consumption and fast serialization and deserialization of
 the sets and hashes.
-  
+
  </description>
  <lead>
   <name>Derick Rethans</name>
@@ -17,10 +17,10 @@ the sets and hashes.
   <email>derick@php.net</email>
   <active>yes</active>
  </lead>
- <date>2012-09-02</date>
- <time>22:44:00</time>
+ <date>2016-05-07</date>
+ <time>17:40:00</time>
  <version>
-  <release>1.0.0</release>
+  <release>2.0.0</release>
   <api>1.0.0</api>
  </version>
  <stability>
@@ -28,9 +28,7 @@ the sets and hashes.
   <api>stable</api>
  </stability>
  <license uri="http://www.php.net/license/3_01.txt">The PHP License</license>
- <notes>
-Implemented ArrayAccess for QuickHashIntSet
- </notes>
+ <notes>PHP7 support</notes>
  <contents>
   <dir name="/">
    <file name="config.m4" role="src" />
@@ -61,7 +59,7 @@ Implemented ArrayAccess for QuickHashIntSet
  <dependencies>
   <required>
    <php>
-    <min>5.2.0</min>
+    <min>5.5.0</min>
    </php>
    <pearinstaller>
     <min>1.4.0b1</min>

--- a/php_quickhash.h
+++ b/php_quickhash.h
@@ -37,10 +37,17 @@ PHP_MINFO_FUNCTION(quickhash);
 
 ZEND_BEGIN_MODULE_GLOBALS(quickhash)
 	/* empty */
-ZEND_END_MODULE_GLOBALS(quickhash) 
+ZEND_END_MODULE_GLOBALS(quickhash)
 
 #ifdef ZTS
+#if PHP_VERSION_ID < 70000
 # define QUICKHASH_G(v) TSRMG(quickhash_globals_id, zend_quickhash_globals *, v)
+#else
+#if defined(COMPILE_DL_QUICKHASH)
+	ZEND_TSRMLS_CACHE_EXTERN();
+#endif
+# define QUICKHASH_G(v) ZEND_TSRMG(quickhash_globals_id, zend_quickhash_globals *, v)
+#endif
 #else
 # define QUICKHASH_G(v) (quickhash_globals.v)
 #endif

--- a/php_quickhash.h
+++ b/php_quickhash.h
@@ -40,14 +40,14 @@ ZEND_BEGIN_MODULE_GLOBALS(quickhash)
 ZEND_END_MODULE_GLOBALS(quickhash)
 
 #ifdef ZTS
-#if PHP_VERSION_ID < 70000
-# define QUICKHASH_G(v) TSRMG(quickhash_globals_id, zend_quickhash_globals *, v)
-#else
-#if defined(COMPILE_DL_QUICKHASH)
-	ZEND_TSRMLS_CACHE_EXTERN();
-#endif
-# define QUICKHASH_G(v) ZEND_TSRMG(quickhash_globals_id, zend_quickhash_globals *, v)
-#endif
+# if PHP_VERSION_ID < 70000
+#  define QUICKHASH_G(v) TSRMG(quickhash_globals_id, zend_quickhash_globals *, v)
+# else
+# if defined(COMPILE_DL_QUICKHASH)
+ZEND_TSRMLS_CACHE_EXTERN();
+# endif
+#  define QUICKHASH_G(v) ZEND_TSRMG(quickhash_globals_id, zend_quickhash_globals *, v)
+# endif
 #else
 # define QUICKHASH_G(v) (quickhash_globals.v)
 #endif

--- a/qh_inthash.c
+++ b/qh_inthash.c
@@ -26,6 +26,21 @@
 #include "quickhash.h"
 #include "zend_interfaces.h"
 
+#if PHP_VERSION_ID < 70000
+#define ZEND_OBJECT_VALUE_PTR zend_object_value
+#define ZEND_OBJECT_PTR void*
+#define Z_QH_INTHASH_OBJ(object) (php_qh_inthash_obj *)object
+#define Z_QH_INTHASH_OBJ_P(object) (php_qh_inthash_obj *)zend_object_store_get_object(object TSRMLS_CC)
+#else
+#define ZEND_OBJECT_VALUE_PTR zend_object*
+#define ZEND_OBJECT_PTR ZEND_OBJECT_VALUE_PTR
+static inline php_qh_inthash_obj* php_qh_inthash_obj_fetch_object(zend_object *obj) {
+      return (php_qh_inthash_obj*)((char*)obj - XtOffsetOf(php_qh_inthash_obj, std));
+}
+#define Z_QH_INTHASH_OBJ(zv) php_qh_inthash_obj_fetch_object(zv)
+#define Z_QH_INTHASH_OBJ_P(zv) Z_QH_INTHASH_OBJ(Z_OBJ_P(zv))
+#endif
+
 zend_class_entry *qh_ce_inthash;
 
 PHPAPI zend_class_entry *php_qh_get_inthash_ce(void)
@@ -35,8 +50,8 @@ PHPAPI zend_class_entry *php_qh_get_inthash_ce(void)
 
 zend_object_handlers qh_object_handlers_inthash;
 
-static void qh_object_free_storage_inthash(void *object TSRMLS_DC);
-static zend_object_value qh_object_new_inthash(zend_class_entry *class_type TSRMLS_DC);
+static void qh_object_free_storage_inthash(ZEND_OBJECT_PTR object TSRMLS_DC);
+static ZEND_OBJECT_VALUE_PTR qh_object_new_inthash(zend_class_entry *class_type TSRMLS_DC);
 
 /* Reflection Information Structs */
 ZEND_BEGIN_ARG_INFO_EX(arginfo_qh_inthash_construct, 0, 0, 1)
@@ -118,52 +133,68 @@ void qh_register_class_inthash(TSRMLS_D)
 	zend_class_entry ce_inthash;
 
 	INIT_CLASS_ENTRY(ce_inthash, "QuickHashIntHash", qh_funcs_inthash);
+
+#if PHP_VERSION_ID < 70000
 	ce_inthash.create_object = qh_object_new_inthash;
 	qh_ce_inthash = zend_register_internal_class_ex(&ce_inthash, php_qh_get_intset_ce(), NULL TSRMLS_CC);
-
+#else
+	qh_ce_inthash = zend_register_internal_class_ex(&ce_inthash, php_qh_get_intset_ce());
+	qh_ce_inthash->create_object = qh_object_new_inthash;
+#endif
 	qh_ce_inthash->get_iterator = qh_inthash_get_iterator;
 	qh_ce_inthash->iterator_funcs.funcs = &qh_inthash_it_funcs;
 
 	memcpy(&qh_object_handlers_inthash, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
 
+#if PHP_VERSION_ID < 70000
 	qh_add_constants(qh_ce_inthash TSRMLS_CC);
+#endif
 
 	zend_class_implements(qh_ce_inthash TSRMLS_CC, 1, zend_ce_arrayaccess);
 }
 
-static inline zend_object_value qh_object_new_inthash_ex(zend_class_entry *class_type, php_qh_inthash_obj **ptr TSRMLS_DC)
+static inline ZEND_OBJECT_VALUE_PTR qh_object_new_inthash_ex(zend_class_entry *class_type, php_qh_inthash_obj **ptr TSRMLS_DC)
 {
 	php_qh_inthash_obj *intern;
+
+#if PHP_VERSION_ID < 70000
 	zend_object_value retval;
 	zval *tmp;
 
 	intern = emalloc(sizeof(php_qh_inthash_obj));
 	memset(intern, 0, sizeof(php_qh_inthash_obj));
+#else
+	intern = ecalloc(1, sizeof(php_qh_inthash_obj) + zend_object_properties_size(class_type));
+#endif
 	if (ptr) {
 		*ptr = intern;
 	}
 
 	zend_object_std_init(&intern->std, class_type TSRMLS_CC);
-#if PHP_MINOR_VERSION > 3
 	object_properties_init(&intern->std, class_type);
-#else
-	zend_hash_copy(intern->std.properties, &class_type->default_properties, (copy_ctor_func_t) zval_add_ref, (void *) &tmp, sizeof(zval *));
-#endif
-	
+#if PHP_VERSION_ID < 70000
 	retval.handle = zend_objects_store_put(intern, (zend_objects_store_dtor_t)zend_objects_destroy_object, (zend_objects_free_object_storage_t) qh_object_free_storage_inthash, NULL TSRMLS_CC);
 	retval.handlers = &qh_object_handlers_inthash;
-	
+
 	return retval;
+#else
+	qh_object_handlers_inthash.offset = XtOffsetOf(php_qh_inthash_obj, std);
+	qh_object_handlers_inthash.dtor_obj = zend_objects_destroy_object;
+	qh_object_handlers_inthash.free_obj = qh_object_free_storage_inthash;
+	intern->std.handlers = &qh_object_handlers_inthash;
+
+	return &intern->std;
+#endif
 }
 
-static zend_object_value qh_object_new_inthash(zend_class_entry *class_type TSRMLS_DC)
+static ZEND_OBJECT_VALUE_PTR qh_object_new_inthash(zend_class_entry *class_type TSRMLS_DC)
 {
 	return qh_object_new_inthash_ex(class_type, NULL TSRMLS_CC);
 }
 
-static void qh_object_free_storage_inthash(void *object TSRMLS_DC)
+static void qh_object_free_storage_inthash(ZEND_OBJECT_PTR object TSRMLS_DC)
 {
-	php_qh_inthash_obj *intern = (php_qh_inthash_obj *) object;
+	php_qh_inthash_obj *intern = Z_QH_INTHASH_OBJ(object);
 
 	if (intern->hash) {
 		qho *tmp_options = intern->hash->options;
@@ -173,7 +204,9 @@ static void qh_object_free_storage_inthash(void *object TSRMLS_DC)
 	}
 
 	zend_object_std_dtor(&intern->std TSRMLS_CC);
+#if PHP_VERSION_ID < 70000
 	efree(object);
+#endif
 }
 
 /* {{{ proto bool QuickHashIntHash::add( int key [ , int value ] )
@@ -187,7 +220,7 @@ PHP_METHOD(QuickHashIntHash, add)
 	if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "Ol|l", &object, qh_ce_inthash, &key, &value) == FAILURE) {
 		RETURN_FALSE;
 	}
-	inthash_obj = (php_qh_inthash_obj *) zend_object_store_get_object(object TSRMLS_CC);
+	inthash_obj = Z_QH_INTHASH_OBJ_P(object);
 	RETURN_BOOL(qhi_hash_add(inthash_obj->hash, (qhv) (int32_t) key, (qhv) (int32_t) value));
 }
 /* }}} */
@@ -204,12 +237,16 @@ PHP_METHOD(QuickHashIntHash, get)
 	if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "Ol", &object, qh_ce_inthash, &key) == FAILURE) {
 		RETURN_FALSE;
 	}
-	inthash_obj = (php_qh_inthash_obj *) zend_object_store_get_object(object TSRMLS_CC);
+	inthash_obj = Z_QH_INTHASH_OBJ_P(object);
 	if (qhi_hash_get(inthash_obj->hash, (qhv) (int32_t) key, &value)) {
 		if (inthash_obj->hash->value_type == QHI_VALUE_TYPE_INT) {
 			RETURN_LONG(value.i);
 		} else if (inthash_obj->hash->value_type == QHI_VALUE_TYPE_STRING) {
+#if PHP_VERSION_ID < 70000
 			RETURN_STRING(value.s, 1);
+#else
+			RETURN_STRING(value.s);
+#endif
 		}
 	}
 	RETURN_FALSE;
@@ -228,7 +265,7 @@ PHP_METHOD(QuickHashIntHash, set)
 	if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "Oll", &object, qh_ce_inthash, &key, &value) == FAILURE) {
 		RETURN_FALSE;
 	}
-	inthash_obj = (php_qh_inthash_obj *) zend_object_store_get_object(object TSRMLS_CC);
+	inthash_obj = Z_QH_INTHASH_OBJ_P(object TSRMLS_CC);
 	RETURN_LONG(qhi_hash_set(inthash_obj->hash, (qhv) (int32_t) key, (qhv) (int32_t) value));
 }
 /* }}} */
@@ -244,7 +281,7 @@ PHP_METHOD(QuickHashIntHash, update)
 	if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "Oll", &object, qh_ce_inthash, &key, &value) == FAILURE) {
 		RETURN_FALSE;
 	}
-	inthash_obj = (php_qh_inthash_obj *) zend_object_store_get_object(object TSRMLS_CC);
+	inthash_obj = Z_QH_INTHASH_OBJ_P(object TSRMLS_CC);
 	RETURN_BOOL(qhi_hash_update(inthash_obj->hash, (qhv) (int32_t) key, (qhv) (int32_t) value));
 }
 /* }}} */
@@ -297,7 +334,7 @@ static uint32_t qh_inthash_initialize_from_file(php_qh_inthash_obj *obj, php_str
 PHP_METHOD(QuickHashIntHash, loadFromFile)
 {
 	char *filename;
-	int   filename_len;
+	size_t   filename_len;
 	long  size = 0, flags = 0;
 	php_stream *stream;
 
@@ -315,7 +352,7 @@ PHP_METHOD(QuickHashIntHash, loadFromFile)
 	qh_instantiate(qh_ce_inthash, return_value TSRMLS_CC);
 	stream = php_stream_open_wrapper(filename, "r", IGNORE_PATH | REPORT_ERRORS, NULL);
 	if (stream) {
-		qh_inthash_initialize_from_file(zend_object_store_get_object(return_value TSRMLS_CC), stream, size, flags TSRMLS_CC);
+		qh_inthash_initialize_from_file(Z_QH_INTHASH_OBJ_P(return_value TSRMLS_CC), stream, size, flags TSRMLS_CC);
 		php_stream_close(stream);
 	}
 	zend_restore_error_handling(&error_handling TSRMLS_CC);
@@ -337,7 +374,7 @@ int qh_inthash_save_to_file(php_stream *stream, php_qh_inthash_obj *obj)
 PHP_METHOD(QuickHashIntHash, saveToFile)
 {
 	char *filename;
-	int   filename_len;
+	size_t   filename_len;
 	zval              *object;
 	php_qh_inthash_obj *inthash_obj;
 	php_stream *stream;
@@ -353,7 +390,7 @@ PHP_METHOD(QuickHashIntHash, saveToFile)
 		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Filename cannot be empty");
 	}
 
-	inthash_obj = (php_qh_inthash_obj *) zend_object_store_get_object(object TSRMLS_CC);
+	inthash_obj = Z_QH_INTHASH_OBJ_P(object TSRMLS_CC);
 	stream = php_stream_open_wrapper(filename, "w", IGNORE_PATH | REPORT_ERRORS, NULL);
 
 	if (stream) {
@@ -408,7 +445,7 @@ static uint32_t qh_inthash_initialize_from_string(php_qh_inthash_obj *obj, char 
 PHP_METHOD(QuickHashIntHash, loadFromString)
 {
 	char    *contents;
-	int      contents_len;
+	size_t      contents_len;
 	long     size = 0, flags = 0;
 
 	zend_error_handling error_handling;
@@ -419,7 +456,7 @@ PHP_METHOD(QuickHashIntHash, loadFromString)
 	}
 
 	qh_instantiate(qh_ce_inthash, return_value TSRMLS_CC);
-	qh_inthash_initialize_from_string(zend_object_store_get_object(return_value TSRMLS_CC), contents, contents_len, size, flags TSRMLS_CC);
+	qh_inthash_initialize_from_string(Z_QH_INTHASH_OBJ_P(return_value TSRMLS_CC), contents, contents_len, size, flags TSRMLS_CC);
 	zend_restore_error_handling(&error_handling TSRMLS_CC);
 }
 /* }}} */
@@ -453,10 +490,15 @@ PHP_METHOD(QuickHashIntHash, saveToString)
 		return;
 	}
 
-	inthash_obj = (php_qh_inthash_obj *) zend_object_store_get_object(object TSRMLS_CC);
+	inthash_obj = Z_QH_INTHASH_OBJ_P(object TSRMLS_CC);
 
 	string = qh_inthash_save_to_string(&string_len, inthash_obj);
 	zend_restore_error_handling(&error_handling TSRMLS_CC);
+#if PHP_VERSION_ID < 70000
 	RETURN_STRINGL(string, string_len, 0);
+#else
+	RETVAL_STRINGL(string, string_len);
+	efree(string);
+#endif
 }
 /* }}} */

--- a/qh_inthash.c
+++ b/qh_inthash.c
@@ -30,7 +30,7 @@
 #define ZEND_OBJECT_VALUE_PTR zend_object_value
 #define ZEND_OBJECT_PTR void*
 #define Z_QH_INTHASH_OBJ(object) (php_qh_inthash_obj *)object
-#define Z_QH_INTHASH_OBJ_P(object) (php_qh_inthash_obj *)zend_object_store_get_object(object TSRMLS_CC)
+#define Z_QH_INTHASH_OBJ_P(object) (php_qh_inthash_obj *)zend_object_store_get_object(object)
 #else
 #define ZEND_OBJECT_VALUE_PTR zend_object*
 #define ZEND_OBJECT_PTR ZEND_OBJECT_VALUE_PTR
@@ -220,7 +220,7 @@ PHP_METHOD(QuickHashIntHash, add)
 	if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "Ol|l", &object, qh_ce_inthash, &key, &value) == FAILURE) {
 		RETURN_FALSE;
 	}
-	inthash_obj = Z_QH_INTHASH_OBJ_P(object);
+	inthash_obj = Z_QH_INTHASH_OBJ_P(object TSRMLS_CC);
 	RETURN_BOOL(qhi_hash_add(inthash_obj->hash, (qhv) (int32_t) key, (qhv) (int32_t) value));
 }
 /* }}} */
@@ -237,7 +237,7 @@ PHP_METHOD(QuickHashIntHash, get)
 	if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "Ol", &object, qh_ce_inthash, &key) == FAILURE) {
 		RETURN_FALSE;
 	}
-	inthash_obj = Z_QH_INTHASH_OBJ_P(object);
+	inthash_obj = Z_QH_INTHASH_OBJ_P(object TSRMLS_CC);
 	if (qhi_hash_get(inthash_obj->hash, (qhv) (int32_t) key, &value)) {
 		if (inthash_obj->hash->value_type == QHI_VALUE_TYPE_INT) {
 			RETURN_LONG(value.i);
@@ -289,6 +289,7 @@ PHP_METHOD(QuickHashIntHash, update)
 /* Validates whether the stream is in the correct format */
 static int qh_inthash_stream_validator(php_stream_statbuf finfo, php_stream *stream, uint32_t *nr_of_elements, uint32_t *value_array_length)
 {
+	TSRMLS_FETCH();
 	char key_buffer[4];
 	uint32_t hash_size;
 

--- a/qh_inthash.c
+++ b/qh_inthash.c
@@ -331,7 +331,7 @@ static uint32_t qh_inthash_initialize_from_file(php_qh_inthash_obj *obj, php_str
 PHP_METHOD(QuickHashIntHash, loadFromFile)
 {
 	char *filename;
-	size_t   filename_len;
+	TYPE_ARG_L   filename_len;
 	long  size = 0, flags = 0;
 	php_stream *stream;
 
@@ -371,7 +371,7 @@ int qh_inthash_save_to_file(php_stream *stream, php_qh_inthash_obj *obj)
 PHP_METHOD(QuickHashIntHash, saveToFile)
 {
 	char *filename;
-	size_t   filename_len;
+	TYPE_ARG_L   filename_len;
 	zval              *object;
 	php_qh_inthash_obj *inthash_obj;
 	php_stream *stream;
@@ -442,7 +442,7 @@ static uint32_t qh_inthash_initialize_from_string(php_qh_inthash_obj *obj, char 
 PHP_METHOD(QuickHashIntHash, loadFromString)
 {
 	char    *contents;
-	size_t      contents_len;
+	TYPE_ARG_L      contents_len;
 	long     size = 0, flags = 0;
 
 	zend_error_handling error_handling;

--- a/qh_inthash.c
+++ b/qh_inthash.c
@@ -27,13 +27,9 @@
 #include "zend_interfaces.h"
 
 #if PHP_VERSION_ID < 70000
-#define ZEND_OBJECT_VALUE_PTR zend_object_value
-#define ZEND_OBJECT_PTR void*
 #define Z_QH_INTHASH_OBJ(object) (php_qh_inthash_obj *)object
 #define Z_QH_INTHASH_OBJ_P(object) (php_qh_inthash_obj *)zend_object_store_get_object(object)
 #else
-#define ZEND_OBJECT_VALUE_PTR zend_object*
-#define ZEND_OBJECT_PTR ZEND_OBJECT_VALUE_PTR
 static inline php_qh_inthash_obj* php_qh_inthash_obj_fetch_object(zend_object *obj) {
       return (php_qh_inthash_obj*)((char*)obj - XtOffsetOf(php_qh_inthash_obj, std));
 }

--- a/qh_inthash.c
+++ b/qh_inthash.c
@@ -301,8 +301,10 @@ PHP_METHOD(QuickHashIntHash, loadFromFile)
 	long  size = 0, flags = 0;
 	php_stream *stream;
 
-	php_set_error_handling(EH_THROW, NULL TSRMLS_CC);
+	zend_error_handling error_handling;
+	zend_replace_error_handling(EH_THROW, NULL, &error_handling TSRMLS_CC);
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|ll", &filename, &filename_len, &size, &flags) == FAILURE) {
+		zend_restore_error_handling(&error_handling TSRMLS_CC);
 		return;
 	}
 
@@ -316,7 +318,7 @@ PHP_METHOD(QuickHashIntHash, loadFromFile)
 		qh_inthash_initialize_from_file(zend_object_store_get_object(return_value TSRMLS_CC), stream, size, flags TSRMLS_CC);
 		php_stream_close(stream);
 	}
-	php_set_error_handling(EH_NORMAL, NULL TSRMLS_CC);
+	zend_restore_error_handling(&error_handling TSRMLS_CC);
 }
 /* }}} */
 
@@ -340,8 +342,10 @@ PHP_METHOD(QuickHashIntHash, saveToFile)
 	php_qh_inthash_obj *inthash_obj;
 	php_stream *stream;
 
-	php_set_error_handling(EH_THROW, NULL TSRMLS_CC);
+	zend_error_handling error_handling;
+	zend_replace_error_handling(EH_THROW, NULL, &error_handling TSRMLS_CC);
 	if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "Os", &object, qh_ce_inthash, &filename, &filename_len) == FAILURE) {
+		zend_restore_error_handling(&error_handling TSRMLS_CC);
 		return;
 	}
 
@@ -356,7 +360,7 @@ PHP_METHOD(QuickHashIntHash, saveToFile)
 		qh_inthash_save_to_file(stream, inthash_obj);
 		php_stream_close(stream);
 	}
-	php_set_error_handling(EH_NORMAL, NULL TSRMLS_CC);
+	zend_restore_error_handling(&error_handling TSRMLS_CC);
 }
 /* }}} */
 
@@ -407,14 +411,16 @@ PHP_METHOD(QuickHashIntHash, loadFromString)
 	int      contents_len;
 	long     size = 0, flags = 0;
 
-	php_set_error_handling(EH_THROW, NULL TSRMLS_CC);
+	zend_error_handling error_handling;
+	zend_replace_error_handling(EH_THROW, NULL, &error_handling TSRMLS_CC);
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|ll", &contents, &contents_len, &size, &flags) == FAILURE) {
+		zend_restore_error_handling(&error_handling TSRMLS_CC);
 		return;
 	}
 
 	qh_instantiate(qh_ce_inthash, return_value TSRMLS_CC);
 	qh_inthash_initialize_from_string(zend_object_store_get_object(return_value TSRMLS_CC), contents, contents_len, size, flags TSRMLS_CC);
-	php_set_error_handling(EH_NORMAL, NULL TSRMLS_CC);
+	zend_restore_error_handling(&error_handling TSRMLS_CC);
 }
 /* }}} */
 
@@ -440,15 +446,17 @@ PHP_METHOD(QuickHashIntHash, saveToString)
 	char              *string;
 	uint32_t           string_len;
 
-	php_set_error_handling(EH_THROW, NULL TSRMLS_CC);
+	zend_error_handling error_handling;
+	zend_replace_error_handling(EH_THROW, NULL, &error_handling TSRMLS_CC);
 	if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "O", &object, qh_ce_inthash) == FAILURE) {
+		zend_restore_error_handling(&error_handling TSRMLS_CC);
 		return;
 	}
 
 	inthash_obj = (php_qh_inthash_obj *) zend_object_store_get_object(object TSRMLS_CC);
 
 	string = qh_inthash_save_to_string(&string_len, inthash_obj);
-	php_set_error_handling(EH_NORMAL, NULL TSRMLS_CC);
+	zend_restore_error_handling(&error_handling TSRMLS_CC);
 	RETURN_STRINGL(string, string_len, 0);
 }
 /* }}} */

--- a/qh_inthash.c
+++ b/qh_inthash.c
@@ -27,14 +27,14 @@
 #include "zend_interfaces.h"
 
 #if PHP_VERSION_ID < 70000
-#define Z_QH_INTHASH_OBJ(object) (php_qh_inthash_obj *)object
-#define Z_QH_INTHASH_OBJ_P(object) (php_qh_inthash_obj *)zend_object_store_get_object(object)
+# define Z_QH_INTHASH_OBJ(object) (php_qh_inthash_obj *)object
+# define Z_QH_INTHASH_OBJ_P(object) (php_qh_inthash_obj *)zend_object_store_get_object(object)
 #else
 static inline php_qh_inthash_obj* php_qh_inthash_obj_fetch_object(zend_object *obj) {
       return (php_qh_inthash_obj*)((char*)obj - XtOffsetOf(php_qh_inthash_obj, std));
 }
-#define Z_QH_INTHASH_OBJ(zv) php_qh_inthash_obj_fetch_object(zv)
-#define Z_QH_INTHASH_OBJ_P(zv) Z_QH_INTHASH_OBJ(Z_OBJ_P(zv))
+# define Z_QH_INTHASH_OBJ(zv) php_qh_inthash_obj_fetch_object(zv)
+# define Z_QH_INTHASH_OBJ_P(zv) Z_QH_INTHASH_OBJ(Z_OBJ_P(zv))
 #endif
 
 zend_class_entry *qh_ce_inthash;
@@ -330,12 +330,12 @@ static uint32_t qh_inthash_initialize_from_file(php_qh_inthash_obj *obj, php_str
    Creates a QuickHashIntHash from data in file filename */
 PHP_METHOD(QuickHashIntHash, loadFromFile)
 {
-	char *filename;
-	TYPE_ARG_L   filename_len;
-	long  size = 0, flags = 0;
-	php_stream *stream;
-
+	char               *filename;
+	TYPE_ARG_L          filename_len;
+	long                size = 0, flags = 0;
+	php_stream         *stream;
 	zend_error_handling error_handling;
+
 	zend_replace_error_handling(EH_THROW, NULL, &error_handling TSRMLS_CC);
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|ll", &filename, &filename_len, &size, &flags) == FAILURE) {
 		zend_restore_error_handling(&error_handling TSRMLS_CC);
@@ -370,13 +370,13 @@ int qh_inthash_save_to_file(php_stream *stream, php_qh_inthash_obj *obj)
    Saves the hash to a file */
 PHP_METHOD(QuickHashIntHash, saveToFile)
 {
-	char *filename;
-	TYPE_ARG_L   filename_len;
-	zval              *object;
+	char               *filename;
+	TYPE_ARG_L          filename_len;
+	zval               *object;
 	php_qh_inthash_obj *inthash_obj;
-	php_stream *stream;
-
+	php_stream         *stream;
 	zend_error_handling error_handling;
+
 	zend_replace_error_handling(EH_THROW, NULL, &error_handling TSRMLS_CC);
 	if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "Os", &object, qh_ce_inthash, &filename, &filename_len) == FAILURE) {
 		zend_restore_error_handling(&error_handling TSRMLS_CC);
@@ -441,11 +441,11 @@ static uint32_t qh_inthash_initialize_from_string(php_qh_inthash_obj *obj, char 
    Creates a QuickHashIntHash from data in a string */
 PHP_METHOD(QuickHashIntHash, loadFromString)
 {
-	char    *contents;
-	TYPE_ARG_L      contents_len;
-	long     size = 0, flags = 0;
-
+	char               *contents;
+	TYPE_ARG_L          contents_len;
+	long                size = 0, flags = 0;
 	zend_error_handling error_handling;
+
 	zend_replace_error_handling(EH_THROW, NULL, &error_handling TSRMLS_CC);
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|ll", &contents, &contents_len, &size, &flags) == FAILURE) {
 		zend_restore_error_handling(&error_handling TSRMLS_CC);
@@ -475,12 +475,12 @@ char *qh_inthash_save_to_string(uint32_t *string_len, php_qh_inthash_obj *obj)
    Returns the hash as a string */
 PHP_METHOD(QuickHashIntHash, saveToString)
 {
-	zval              *object;
+	zval               *object;
 	php_qh_inthash_obj *inthash_obj;
-	char              *string;
-	uint32_t           string_len;
-
+	char               *string;
+	uint32_t            string_len;
 	zend_error_handling error_handling;
+
 	zend_replace_error_handling(EH_THROW, NULL, &error_handling TSRMLS_CC);
 	if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "O", &object, qh_ce_inthash) == FAILURE) {
 		zend_restore_error_handling(&error_handling TSRMLS_CC);

--- a/qh_inthash.h
+++ b/qh_inthash.h
@@ -21,12 +21,12 @@
 #define PHP_QUICKHASH_INTHASH_H
 
 #include "lib/quickhash.h"
+#include "quickhash.h"
 
 typedef struct _php_qh_inthash_obj php_qh_inthash_obj;
 
 struct _php_qh_inthash_obj {
-	zend_object   std;
-	qhi          *hash;
+	QH_PHP_OBJ
 };
 
 PHP_METHOD(QuickHashIntHash, add);

--- a/qh_intset.c
+++ b/qh_intset.c
@@ -186,13 +186,14 @@ PHP_METHOD(QuickHashIntSet, __construct)
 	long size;
 	long flags = 0;
 
-	php_set_error_handling(EH_THROW, NULL TSRMLS_CC);
+	zend_error_handling error_handling;
+	zend_replace_error_handling(EH_THROW, NULL, &error_handling TSRMLS_CC);
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l|l", &size, &flags) == SUCCESS) {
 		if (!qh_intset_initialize(zend_object_store_get_object(getThis() TSRMLS_CC), size, flags TSRMLS_CC)) {
 			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Could not initialize set.");
 		}
 	}
-	php_set_error_handling(EH_NORMAL, NULL TSRMLS_CC);
+	zend_restore_error_handling(&error_handling TSRMLS_CC);
 }
 /* }}} */
 
@@ -297,8 +298,10 @@ PHP_METHOD(QuickHashIntSet, loadFromFile)
 	long  size = 0, flags = 0;
 	php_stream *stream;
 
-	php_set_error_handling(EH_THROW, NULL TSRMLS_CC);
+	zend_error_handling error_handling;
+	zend_replace_error_handling(EH_THROW, NULL, &error_handling TSRMLS_CC);
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|ll", &filename, &filename_len, &size, &flags) == FAILURE) {
+		zend_restore_error_handling(&error_handling TSRMLS_CC);
 		return;
 	}
 
@@ -312,7 +315,7 @@ PHP_METHOD(QuickHashIntSet, loadFromFile)
 		qh_intset_initialize_from_file(zend_object_store_get_object(return_value TSRMLS_CC), stream, size, flags TSRMLS_CC);
 		php_stream_close(stream);
 	}
-	php_set_error_handling(EH_NORMAL, NULL TSRMLS_CC);
+	zend_restore_error_handling(&error_handling TSRMLS_CC);
 }
 /* }}} */
 
@@ -336,8 +339,10 @@ PHP_METHOD(QuickHashIntSet, saveToFile)
 	php_qh_intset_obj *intset_obj;
 	php_stream *stream;
 
-	php_set_error_handling(EH_THROW, NULL TSRMLS_CC);
+	zend_error_handling error_handling;
+	zend_replace_error_handling(EH_THROW, NULL, &error_handling TSRMLS_CC);
 	if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "Os", &object, qh_ce_intset, &filename, &filename_len) == FAILURE) {
+		zend_restore_error_handling(&error_handling TSRMLS_CC);
 		return;
 	}
 
@@ -352,7 +357,7 @@ PHP_METHOD(QuickHashIntSet, saveToFile)
 		qh_intset_save_to_file(stream, intset_obj);
 		php_stream_close(stream);
 	}
-	php_set_error_handling(EH_NORMAL, NULL TSRMLS_CC);
+	zend_restore_error_handling(&error_handling TSRMLS_CC);
 }
 /* }}} */
 
@@ -394,14 +399,16 @@ PHP_METHOD(QuickHashIntSet, loadFromString)
 	int      contents_len;
 	long     size = 0, flags = 0;
 
-	php_set_error_handling(EH_THROW, NULL TSRMLS_CC);
+	zend_error_handling error_handling;
+	zend_replace_error_handling(EH_THROW, NULL, &error_handling TSRMLS_CC);
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|ll", &contents, &contents_len, &size, &flags) == FAILURE) {
+		zend_restore_error_handling(&error_handling TSRMLS_CC);
 		return;
 	}
 
 	qh_instantiate(qh_ce_intset, return_value TSRMLS_CC);
 	qh_intset_initialize_from_string(zend_object_store_get_object(return_value TSRMLS_CC), contents, contents_len, size, flags TSRMLS_CC);
-	php_set_error_handling(EH_NORMAL, NULL TSRMLS_CC);
+	zend_restore_error_handling(&error_handling TSRMLS_CC);
 }
 /* }}} */
 
@@ -427,15 +434,17 @@ PHP_METHOD(QuickHashIntSet, saveToString)
 	char              *string;
 	uint32_t           string_len;
 
-	php_set_error_handling(EH_THROW, NULL TSRMLS_CC);
+	zend_error_handling error_handling;
+	zend_replace_error_handling(EH_THROW, NULL, &error_handling TSRMLS_CC);
 	if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "O", &object, qh_ce_intset) == FAILURE) {
+		zend_restore_error_handling(&error_handling TSRMLS_CC);
 		return;
 	}
 
 	intset_obj = (php_qh_intset_obj *) zend_object_store_get_object(object TSRMLS_CC);
 
 	string = qh_intset_save_to_string(&string_len, intset_obj);
-	php_set_error_handling(EH_NORMAL, NULL TSRMLS_CC);
+	zend_restore_error_handling(&error_handling TSRMLS_CC);
 	RETURN_STRINGL(string, string_len, 0);
 }
 /* }}} */

--- a/qh_intset.c
+++ b/qh_intset.c
@@ -204,10 +204,10 @@ static int qh_intset_initialize(php_qh_intset_obj *obj, long size, long flags TS
    Creates a new QuickHashIntSet */
 PHP_METHOD(QuickHashIntSet, __construct)
 {
-	long size;
-	long flags = 0;
-
+	long                size;
+	long                flags = 0;
 	zend_error_handling error_handling;
+
 	zend_replace_error_handling(EH_THROW, NULL, &error_handling TSRMLS_CC);
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l|l", &size, &flags) == SUCCESS) {
 		if (!qh_intset_initialize(Z_QH_INTSET_OBJ_P(getThis() TSRMLS_CC), size, flags TSRMLS_CC)) {
@@ -314,12 +314,12 @@ static uint32_t qh_intset_initialize_from_file(php_qh_intset_obj *obj, php_strea
    Creates a QuickHashIntSet from data in file filename */
 PHP_METHOD(QuickHashIntSet, loadFromFile)
 {
-	char *filename;
-	TYPE_ARG_L   filename_len;
-	long  size = 0, flags = 0;
-	php_stream *stream;
-
+	char               *filename;
+	TYPE_ARG_L          filename_len;
+	long                size = 0, flags = 0;
+	php_stream         *stream;
 	zend_error_handling error_handling;
+
 	zend_replace_error_handling(EH_THROW, NULL, &error_handling TSRMLS_CC);
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|ll", &filename, &filename_len, &size, &flags) == FAILURE) {
 		zend_restore_error_handling(&error_handling TSRMLS_CC);
@@ -354,13 +354,13 @@ int qh_intset_save_to_file(php_stream *stream, php_qh_intset_obj *obj)
    Saves the hash to a file */
 PHP_METHOD(QuickHashIntSet, saveToFile)
 {
-	char *filename;
-	TYPE_ARG_L   filename_len;
-	zval              *object;
-	php_qh_intset_obj *intset_obj;
-	php_stream *stream;
-
+	char               *filename;
+	TYPE_ARG_L          filename_len;
+	zval               *object;
+	php_qh_intset_obj  *intset_obj;
+	php_stream         *stream;
 	zend_error_handling error_handling;
+
 	zend_replace_error_handling(EH_THROW, NULL, &error_handling TSRMLS_CC);
 	if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "Os", &object, qh_ce_intset, &filename, &filename_len) == FAILURE) {
 		zend_restore_error_handling(&error_handling TSRMLS_CC);
@@ -416,11 +416,11 @@ static uint32_t qh_intset_initialize_from_string(php_qh_intset_obj *obj, char *c
    Creates a QuickHashIntSet from data in a string */
 PHP_METHOD(QuickHashIntSet, loadFromString)
 {
-	char    *contents;
-	TYPE_ARG_L      contents_len;
-	long     size = 0, flags = 0;
-
+	char               *contents;
+	TYPE_ARG_L          contents_len;
+	long                size = 0, flags = 0;
 	zend_error_handling error_handling;
+
 	zend_replace_error_handling(EH_THROW, NULL, &error_handling TSRMLS_CC);
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|ll", &contents, &contents_len, &size, &flags) == FAILURE) {
 		zend_restore_error_handling(&error_handling TSRMLS_CC);
@@ -450,12 +450,12 @@ char *qh_intset_save_to_string(uint32_t *string_len, php_qh_intset_obj *obj)
    Returns the hash as a string */
 PHP_METHOD(QuickHashIntSet, saveToString)
 {
-	zval              *object;
-	php_qh_intset_obj *intset_obj;
-	char              *string;
-	uint32_t           string_len;
-
+	zval               *object;
+	php_qh_intset_obj  *intset_obj;
+	char               *string;
+	uint32_t            string_len;
 	zend_error_handling error_handling;
+
 	zend_replace_error_handling(EH_THROW, NULL, &error_handling TSRMLS_CC);
 	if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "O", &object, qh_ce_intset) == FAILURE) {
 		zend_restore_error_handling(&error_handling TSRMLS_CC);

--- a/qh_intset.c
+++ b/qh_intset.c
@@ -315,7 +315,7 @@ static uint32_t qh_intset_initialize_from_file(php_qh_intset_obj *obj, php_strea
 PHP_METHOD(QuickHashIntSet, loadFromFile)
 {
 	char *filename;
-	size_t   filename_len;
+	TYPE_ARG_L   filename_len;
 	long  size = 0, flags = 0;
 	php_stream *stream;
 
@@ -355,7 +355,7 @@ int qh_intset_save_to_file(php_stream *stream, php_qh_intset_obj *obj)
 PHP_METHOD(QuickHashIntSet, saveToFile)
 {
 	char *filename;
-	size_t   filename_len;
+	TYPE_ARG_L   filename_len;
 	zval              *object;
 	php_qh_intset_obj *intset_obj;
 	php_stream *stream;
@@ -417,7 +417,7 @@ static uint32_t qh_intset_initialize_from_string(php_qh_intset_obj *obj, char *c
 PHP_METHOD(QuickHashIntSet, loadFromString)
 {
 	char    *contents;
-	size_t      contents_len;
+	TYPE_ARG_L      contents_len;
 	long     size = 0, flags = 0;
 
 	zend_error_handling error_handling;

--- a/qh_intset.c
+++ b/qh_intset.c
@@ -25,6 +25,12 @@
 #include "quickhash.h"
 #include "zend_interfaces.h"
 
+#if PHP_VERSION_ID >= 70000
+inline php_qh_intset_obj* php_qh_intset_obj_fetch_object(zend_object *obj) {
+      return (php_qh_intset_obj*)((char*)obj - XtOffsetOf(php_qh_intset_obj, std));
+}
+#endif
+
 zend_class_entry *qh_ce_intset;
 
 PHPAPI zend_class_entry *php_qh_get_intset_ce(void)
@@ -34,8 +40,8 @@ PHPAPI zend_class_entry *php_qh_get_intset_ce(void)
 
 zend_object_handlers qh_object_handlers_intset;
 
-static void qh_object_free_storage_intset(void *object TSRMLS_DC);
-static zend_object_value qh_object_new_intset(zend_class_entry *class_type TSRMLS_DC);
+static void qh_object_free_storage_intset(ZEND_OBJECT_PTR object TSRMLS_DC);
+static ZEND_OBJECT_VALUE_PTR qh_object_new_intset(zend_class_entry *class_type TSRMLS_DC);
 
 /* Reflection Information Structs */
 ZEND_BEGIN_ARG_INFO_EX(arginfo_qh_intset_construct, 0, 0, 1)
@@ -105,8 +111,13 @@ void qh_register_class_intset(TSRMLS_D)
 	zend_class_entry ce_intset;
 
 	INIT_CLASS_ENTRY(ce_intset, "QuickHashIntSet", qh_funcs_intset);
+#if PHP_VERSION_ID < 70000
 	ce_intset.create_object = qh_object_new_intset;
 	qh_ce_intset = zend_register_internal_class_ex(&ce_intset, NULL, NULL TSRMLS_CC);
+#else
+	qh_ce_intset = zend_register_internal_class_ex(&ce_intset, NULL);
+	qh_ce_intset->create_object = qh_object_new_intset;
+#endif
 
 	qh_ce_intset->get_iterator = qh_intset_get_iterator;
 	qh_ce_intset->iterator_funcs.funcs = &qh_intset_it_funcs;
@@ -118,39 +129,47 @@ void qh_register_class_intset(TSRMLS_D)
 	zend_class_implements(qh_ce_intset TSRMLS_CC, 1, zend_ce_arrayaccess);
 }
 
-static inline zend_object_value qh_object_new_intset_ex(zend_class_entry *class_type, php_qh_intset_obj **ptr TSRMLS_DC)
+static inline ZEND_OBJECT_VALUE_PTR qh_object_new_intset_ex(zend_class_entry *class_type, php_qh_intset_obj **ptr TSRMLS_DC)
 {
 	php_qh_intset_obj *intern;
+#if PHP_VERSION_ID < 70000
 	zend_object_value retval;
 	zval *tmp;
 
 	intern = emalloc(sizeof(php_qh_intset_obj));
 	memset(intern, 0, sizeof(php_qh_intset_obj));
+#else
+	intern = ecalloc(1, sizeof(php_qh_intset_obj) + zend_object_properties_size(class_type));
+#endif
 	if (ptr) {
 		*ptr = intern;
 	}
 
 	zend_object_std_init(&intern->std, class_type TSRMLS_CC);
-#if PHP_MINOR_VERSION > 3
 	object_properties_init(&intern->std, class_type);
-#else
-	zend_hash_copy(intern->std.properties, &class_type->default_properties, (copy_ctor_func_t) zval_add_ref, (void *) &tmp, sizeof(zval *));
-#endif
-	
+#if PHP_VERSION_ID < 70000
 	retval.handle = zend_objects_store_put(intern, (zend_objects_store_dtor_t)zend_objects_destroy_object, (zend_objects_free_object_storage_t) qh_object_free_storage_intset, NULL TSRMLS_CC);
 	retval.handlers = &qh_object_handlers_intset;
-	
+
 	return retval;
+#else
+	qh_object_handlers_intset.offset = XtOffsetOf(php_qh_intset_obj, std);
+	qh_object_handlers_intset.dtor_obj = zend_objects_destroy_object;
+	qh_object_handlers_intset.free_obj = qh_object_free_storage_intset;
+	intern->std.handlers = &qh_object_handlers_intset;
+
+	return &intern->std;
+#endif
 }
 
-static zend_object_value qh_object_new_intset(zend_class_entry *class_type TSRMLS_DC)
+static ZEND_OBJECT_VALUE_PTR qh_object_new_intset(zend_class_entry *class_type TSRMLS_DC)
 {
 	return qh_object_new_intset_ex(class_type, NULL TSRMLS_CC);
 }
 
-static void qh_object_free_storage_intset(void *object TSRMLS_DC)
+static void qh_object_free_storage_intset(ZEND_OBJECT_PTR object TSRMLS_DC)
 {
-	php_qh_intset_obj *intern = (php_qh_intset_obj *) object;
+	php_qh_intset_obj *intern = Z_QH_INTSET_OBJ(object);
 
 	if (intern->hash) {
 		qho *tmp_options = intern->hash->options;
@@ -160,7 +179,9 @@ static void qh_object_free_storage_intset(void *object TSRMLS_DC)
 	}
 
 	zend_object_std_dtor(&intern->std TSRMLS_CC);
+#if PHP_VERSION_ID < 70000
 	efree(object);
+#endif
 }
 
 
@@ -189,7 +210,7 @@ PHP_METHOD(QuickHashIntSet, __construct)
 	zend_error_handling error_handling;
 	zend_replace_error_handling(EH_THROW, NULL, &error_handling TSRMLS_CC);
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l|l", &size, &flags) == SUCCESS) {
-		if (!qh_intset_initialize(zend_object_store_get_object(getThis() TSRMLS_CC), size, flags TSRMLS_CC)) {
+		if (!qh_intset_initialize(Z_QH_INTSET_OBJ_P(getThis() TSRMLS_CC), size, flags TSRMLS_CC)) {
 			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Could not initialize set.");
 		}
 	}
@@ -207,7 +228,7 @@ PHP_METHOD(QuickHashIntSet, getSize)
 	if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "O", &object, qh_ce_intset) == FAILURE) {
 		RETURN_FALSE;
 	}
-	intset_obj = (php_qh_intset_obj *) zend_object_store_get_object(object TSRMLS_CC);
+	intset_obj = Z_QH_INTSET_OBJ_P(object TSRMLS_CC);
 	RETURN_LONG(intset_obj->hash->element_count);
 }
 /* }}} */
@@ -224,7 +245,7 @@ PHP_METHOD(QuickHashIntSet, add)
 	if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "Ol|l", &object, qh_ce_intset, &key, &dummy) == FAILURE) {
 		RETURN_FALSE;
 	}
-	intset_obj = (php_qh_intset_obj *) zend_object_store_get_object(object TSRMLS_CC);
+	intset_obj = Z_QH_INTSET_OBJ_P(object TSRMLS_CC);
 	RETURN_BOOL(qhi_set_add(intset_obj->hash, (qhv) (int32_t) key));
 }
 /* }}} */
@@ -240,7 +261,7 @@ PHP_METHOD(QuickHashIntSet, exists)
 	if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "Ol", &object, qh_ce_intset, &key) == FAILURE) {
 		RETURN_FALSE;
 	}
-	intset_obj = (php_qh_intset_obj *) zend_object_store_get_object(object TSRMLS_CC);
+	intset_obj = Z_QH_INTSET_OBJ_P(object TSRMLS_CC);
 	RETURN_BOOL(qhi_set_exists(intset_obj->hash, (qhv) (int32_t) key));
 }
 /* }}} */
@@ -256,7 +277,7 @@ PHP_METHOD(QuickHashIntSet, delete)
 	if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "Ol", &object, qh_ce_intset, &key) == FAILURE) {
 		RETURN_FALSE;
 	}
-	intset_obj = (php_qh_intset_obj *) zend_object_store_get_object(object TSRMLS_CC);
+	intset_obj = Z_QH_INTSET_OBJ_P(object TSRMLS_CC);
 	RETURN_BOOL(qhi_set_delete(intset_obj->hash, (qhv) (int32_t) key));
 }
 /* }}} */
@@ -294,7 +315,7 @@ static uint32_t qh_intset_initialize_from_file(php_qh_intset_obj *obj, php_strea
 PHP_METHOD(QuickHashIntSet, loadFromFile)
 {
 	char *filename;
-	int   filename_len;
+	size_t   filename_len;
 	long  size = 0, flags = 0;
 	php_stream *stream;
 
@@ -312,7 +333,7 @@ PHP_METHOD(QuickHashIntSet, loadFromFile)
 	qh_instantiate(qh_ce_intset, return_value TSRMLS_CC);
 	stream = php_stream_open_wrapper(filename, "r", IGNORE_PATH | REPORT_ERRORS, NULL);
 	if (stream) {
-		qh_intset_initialize_from_file(zend_object_store_get_object(return_value TSRMLS_CC), stream, size, flags TSRMLS_CC);
+		qh_intset_initialize_from_file(Z_QH_INTSET_OBJ_P(return_value TSRMLS_CC), stream, size, flags TSRMLS_CC);
 		php_stream_close(stream);
 	}
 	zend_restore_error_handling(&error_handling TSRMLS_CC);
@@ -334,7 +355,7 @@ int qh_intset_save_to_file(php_stream *stream, php_qh_intset_obj *obj)
 PHP_METHOD(QuickHashIntSet, saveToFile)
 {
 	char *filename;
-	int   filename_len;
+	size_t   filename_len;
 	zval              *object;
 	php_qh_intset_obj *intset_obj;
 	php_stream *stream;
@@ -350,7 +371,7 @@ PHP_METHOD(QuickHashIntSet, saveToFile)
 		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Filename cannot be empty");
 	}
 
-	intset_obj = (php_qh_intset_obj *) zend_object_store_get_object(object TSRMLS_CC);
+	intset_obj = Z_QH_INTSET_OBJ_P(object TSRMLS_CC);
 	stream = php_stream_open_wrapper(filename, "w", IGNORE_PATH | REPORT_ERRORS, NULL);
 
 	if (stream) {
@@ -396,7 +417,7 @@ static uint32_t qh_intset_initialize_from_string(php_qh_intset_obj *obj, char *c
 PHP_METHOD(QuickHashIntSet, loadFromString)
 {
 	char    *contents;
-	int      contents_len;
+	size_t      contents_len;
 	long     size = 0, flags = 0;
 
 	zend_error_handling error_handling;
@@ -407,7 +428,7 @@ PHP_METHOD(QuickHashIntSet, loadFromString)
 	}
 
 	qh_instantiate(qh_ce_intset, return_value TSRMLS_CC);
-	qh_intset_initialize_from_string(zend_object_store_get_object(return_value TSRMLS_CC), contents, contents_len, size, flags TSRMLS_CC);
+	qh_intset_initialize_from_string(Z_QH_INTSET_OBJ_P(return_value TSRMLS_CC), contents, contents_len, size, flags TSRMLS_CC);
 	zend_restore_error_handling(&error_handling TSRMLS_CC);
 }
 /* }}} */
@@ -441,10 +462,15 @@ PHP_METHOD(QuickHashIntSet, saveToString)
 		return;
 	}
 
-	intset_obj = (php_qh_intset_obj *) zend_object_store_get_object(object TSRMLS_CC);
+	intset_obj = Z_QH_INTSET_OBJ_P(object TSRMLS_CC);
 
 	string = qh_intset_save_to_string(&string_len, intset_obj);
 	zend_restore_error_handling(&error_handling TSRMLS_CC);
+#if PHP_VERSION_ID < 70000
 	RETURN_STRINGL(string, string_len, 0);
+#else
+	RETVAL_STRINGL(string, string_len);
+	efree(string);
+#endif
 }
 /* }}} */

--- a/qh_intset.h
+++ b/qh_intset.h
@@ -25,6 +25,14 @@
 
 typedef struct _php_qh_intset_obj php_qh_intset_obj;
 
+#if PHP_VERSION_ID < 70000
+# define Z_QH_INTSET_OBJ(zv) (php_qh_intset_obj*)zv
+# define Z_QH_INTSET_OBJ_P(zv) zend_object_store_get_object(zv)
+#else
+# define Z_QH_INTSET_OBJ(zv) php_qh_intset_obj_fetch_object(zv)
+# define Z_QH_INTSET_OBJ_P(zv) Z_QH_INTSET_OBJ(Z_OBJ_P(zv))
+#endif
+
 struct _php_qh_intset_obj {
 	QH_PHP_OBJ
 };
@@ -41,5 +49,8 @@ PHP_METHOD(QuickHashIntSet, saveToString);
 
 void qh_register_class_intset(TSRMLS_D);
 PHPAPI zend_class_entry *php_qh_get_intset_ce(void);
+#if PHP_VERSION_ID >= 70000
+php_qh_intset_obj* php_qh_intset_obj_fetch_object(zend_object *obj);
+#endif
 
 #endif

--- a/qh_intset.h
+++ b/qh_intset.h
@@ -21,12 +21,12 @@
 #define PHP_QUICKHASH_INTSET_H
 
 #include "lib/quickhash.h"
+#include "quickhash.h"
 
 typedef struct _php_qh_intset_obj php_qh_intset_obj;
 
 struct _php_qh_intset_obj {
-	zend_object   std;
-	qhi          *hash;
+	QH_PHP_OBJ
 };
 
 PHP_METHOD(QuickHashIntSet, __construct);

--- a/qh_intstringhash.c
+++ b/qh_intstringhash.c
@@ -226,10 +226,10 @@ static int qh_intstringhash_initialize(php_qh_intstringhash_obj *obj, long size,
    Creates a new QuickHashIntStringHash */
 PHP_METHOD(QuickHashIntStringHash, __construct)
 {
-	long size;
-	long flags = 0;
-
+	long                size;
+	long                flags = 0;
 	zend_error_handling error_handling;
+
 	zend_replace_error_handling(EH_THROW, NULL, &error_handling TSRMLS_CC);
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l|l", &size, &flags) == SUCCESS) {
 		if (!qh_intstringhash_initialize(Z_QH_INTSTRINGHASH_OBJ_P(getThis() TSRMLS_CC), size, flags TSRMLS_CC)) {
@@ -244,11 +244,11 @@ PHP_METHOD(QuickHashIntStringHash, __construct)
    Adds an element with key key and value value to the hash */
 PHP_METHOD(QuickHashIntStringHash, add)
 {
-	zval              *object;
+	zval                     *object;
 	php_qh_intstringhash_obj *intstringhash_obj;
-	long               key;
-	char              *value;
-	TYPE_ARG_L               value_len;
+	long                      key;
+	char                     *value;
+	TYPE_ARG_L                value_len;
 
 	if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "Ols", &object, qh_ce_intstringhash, &key, &value, &value_len) == FAILURE) {
 		RETURN_FALSE;
@@ -262,11 +262,11 @@ PHP_METHOD(QuickHashIntStringHash, add)
    Updates the value of an element if it exists, or otherwise adds a new element */
 PHP_METHOD(QuickHashIntStringHash, set)
 {
-	zval               *object;
+	zval                     *object;
 	php_qh_intstringhash_obj *intstringhash_obj;
-	long                key;
-	char              *value;
-	TYPE_ARG_L               value_len;
+	long                      key;
+	char                     *value;
+	TYPE_ARG_L                value_len;
 
 	if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "Ols", &object, qh_ce_intstringhash, &key, &value, &value_len) == FAILURE) {
 		RETURN_FALSE;
@@ -280,11 +280,11 @@ PHP_METHOD(QuickHashIntStringHash, set)
    Updates the value of an element for key key */
 PHP_METHOD(QuickHashIntStringHash, update)
 {
-	zval              *object;
+	zval                     *object;
 	php_qh_intstringhash_obj *intstringhash_obj;
-	long                key;
-	char              *value;
-	TYPE_ARG_L               value_len;
+	long                      key;
+	char                     *value;
+	TYPE_ARG_L                value_len;
 
 	if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "Ols", &object, qh_ce_intstringhash, &key, &value, &value_len) == FAILURE) {
 		RETURN_FALSE;
@@ -346,12 +346,12 @@ static uint32_t qh_intstringhash_initialize_from_file(php_qh_intstringhash_obj *
    Creates a QuickHashIntStringHash from data in file filename */
 PHP_METHOD(QuickHashIntStringHash, loadFromFile)
 {
-	char *filename;
-	TYPE_ARG_L   filename_len;
-	long  size = 0, flags = 0;
-	php_stream *stream;
-
+	char               *filename;
+	TYPE_ARG_L          filename_len;
+	long                size = 0, flags = 0;
+	php_stream         *stream;
 	zend_error_handling error_handling;
+
 	zend_replace_error_handling(EH_THROW, NULL, &error_handling TSRMLS_CC);
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|ll", &filename, &filename_len, &size, &flags) == FAILURE) {
 		zend_restore_error_handling(&error_handling TSRMLS_CC);
@@ -386,13 +386,13 @@ int qh_intstringhash_save_to_file(php_stream *stream, php_qh_intstringhash_obj *
    Saves the hash to a file */
 PHP_METHOD(QuickHashIntStringHash, saveToFile)
 {
-	char *filename;
-	TYPE_ARG_L   filename_len;
-	zval              *object;
+	char                     *filename;
+	TYPE_ARG_L                filename_len;
+	zval                     *object;
 	php_qh_intstringhash_obj *intstringhash_obj;
-	php_stream *stream;
+	php_stream               *stream;
+	zend_error_handling       error_handling;
 
-	zend_error_handling error_handling;
 	zend_replace_error_handling(EH_THROW, NULL, &error_handling TSRMLS_CC);
 	if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "Os", &object, qh_ce_intstringhash, &filename, &filename_len) == FAILURE) {
 		zend_restore_error_handling(&error_handling TSRMLS_CC);
@@ -459,11 +459,11 @@ static uint32_t qh_intstringhash_initialize_from_string(php_qh_intstringhash_obj
    Creates a QuickHashIntStringHash from data in a string */
 PHP_METHOD(QuickHashIntStringHash, loadFromString)
 {
-	char    *contents;
-	TYPE_ARG_L      contents_len;
-	long     size = 0, flags = 0;
-
+	char               *contents;
+	TYPE_ARG_L          contents_len;
+	long                size = 0, flags = 0;
 	zend_error_handling error_handling;
+
 	zend_replace_error_handling(EH_THROW, NULL, &error_handling TSRMLS_CC);
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|ll", &contents, &contents_len, &size, &flags) == FAILURE) {
 		zend_restore_error_handling(&error_handling TSRMLS_CC);
@@ -493,12 +493,12 @@ char *qh_intstringhash_save_to_string(uint32_t *string_len, php_qh_intstringhash
    Returns the hash as a string */
 PHP_METHOD(QuickHashIntStringHash, saveToString)
 {
-	zval              *object;
+	zval                     *object;
 	php_qh_intstringhash_obj *intstringhash_obj;
-	char              *string;
-	uint32_t           string_len;
+	char                     *string;
+	uint32_t                  string_len;
+	zend_error_handling       error_handling;
 
-	zend_error_handling error_handling;
 	zend_replace_error_handling(EH_THROW, NULL, &error_handling TSRMLS_CC);
 	if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "O", &object, qh_ce_intstringhash) == FAILURE) {
 		zend_restore_error_handling(&error_handling TSRMLS_CC);

--- a/qh_intstringhash.c
+++ b/qh_intstringhash.c
@@ -248,7 +248,7 @@ PHP_METHOD(QuickHashIntStringHash, add)
 	php_qh_intstringhash_obj *intstringhash_obj;
 	long               key;
 	char              *value;
-	size_t               value_len;
+	TYPE_ARG_L               value_len;
 
 	if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "Ols", &object, qh_ce_intstringhash, &key, &value, &value_len) == FAILURE) {
 		RETURN_FALSE;
@@ -266,7 +266,7 @@ PHP_METHOD(QuickHashIntStringHash, set)
 	php_qh_intstringhash_obj *intstringhash_obj;
 	long                key;
 	char              *value;
-	size_t               value_len;
+	TYPE_ARG_L               value_len;
 
 	if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "Ols", &object, qh_ce_intstringhash, &key, &value, &value_len) == FAILURE) {
 		RETURN_FALSE;
@@ -284,7 +284,7 @@ PHP_METHOD(QuickHashIntStringHash, update)
 	php_qh_intstringhash_obj *intstringhash_obj;
 	long                key;
 	char              *value;
-	size_t               value_len;
+	TYPE_ARG_L               value_len;
 
 	if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "Ols", &object, qh_ce_intstringhash, &key, &value, &value_len) == FAILURE) {
 		RETURN_FALSE;
@@ -347,7 +347,7 @@ static uint32_t qh_intstringhash_initialize_from_file(php_qh_intstringhash_obj *
 PHP_METHOD(QuickHashIntStringHash, loadFromFile)
 {
 	char *filename;
-	size_t   filename_len;
+	TYPE_ARG_L   filename_len;
 	long  size = 0, flags = 0;
 	php_stream *stream;
 
@@ -387,7 +387,7 @@ int qh_intstringhash_save_to_file(php_stream *stream, php_qh_intstringhash_obj *
 PHP_METHOD(QuickHashIntStringHash, saveToFile)
 {
 	char *filename;
-	size_t   filename_len;
+	TYPE_ARG_L   filename_len;
 	zval              *object;
 	php_qh_intstringhash_obj *intstringhash_obj;
 	php_stream *stream;
@@ -460,7 +460,7 @@ static uint32_t qh_intstringhash_initialize_from_string(php_qh_intstringhash_obj
 PHP_METHOD(QuickHashIntStringHash, loadFromString)
 {
 	char    *contents;
-	size_t      contents_len;
+	TYPE_ARG_L      contents_len;
 	long     size = 0, flags = 0;
 
 	zend_error_handling error_handling;

--- a/qh_intstringhash.c
+++ b/qh_intstringhash.c
@@ -27,6 +27,17 @@
 #include "quickhash.h"
 #include "zend_interfaces.h"
 
+#if PHP_VERSION_ID < 70000
+# define Z_QH_INTSTRINGHASH_OBJ(zv) (php_qh_intstringhash_obj*)zv
+# define Z_QH_INTSTRINGHASH_OBJ_P(zv) zend_object_store_get_object(zv)
+#else
+static inline php_qh_intstringhash_obj* php_qh_intstringhash_obj_fetch_object(zend_object *obj) {
+      return (php_qh_intstringhash_obj*)((char*)obj - XtOffsetOf(php_qh_intstringhash_obj, std));
+}
+# define Z_QH_INTSTRINGHASH_OBJ(zv) php_qh_intstringhash_obj_fetch_object(zv)
+# define Z_QH_INTSTRINGHASH_OBJ_P(zv) Z_QH_INTSTRINGHASH_OBJ(Z_OBJ_P(zv))
+#endif
+
 zend_class_entry *qh_ce_intstringhash;
 
 PHPAPI zend_class_entry *php_qh_get_intstringhash_ce(void)
@@ -36,8 +47,8 @@ PHPAPI zend_class_entry *php_qh_get_intstringhash_ce(void)
 
 zend_object_handlers qh_object_handlers_intstringhash;
 
-static void qh_object_free_storage_intstringhash(void *object TSRMLS_DC);
-static zend_object_value qh_object_new_intstringhash(zend_class_entry *class_type TSRMLS_DC);
+static void qh_object_free_storage_intstringhash(ZEND_OBJECT_PTR object TSRMLS_DC);
+static ZEND_OBJECT_VALUE_PTR qh_object_new_intstringhash(zend_class_entry *class_type TSRMLS_DC);
 
 /* Reflection Information Structs */
 ZEND_BEGIN_ARG_INFO_EX(arginfo_qh_intstringhash_construct, 0, 0, 1)
@@ -121,52 +132,65 @@ void qh_register_class_intstringhash(TSRMLS_D)
 	zend_class_entry ce_intstringhash;
 
 	INIT_CLASS_ENTRY(ce_intstringhash, "QuickHashIntStringHash", qh_funcs_intstringhash);
+#if PHP_VERSION_ID < 70000
 	ce_intstringhash.create_object = qh_object_new_intstringhash;
 	qh_ce_intstringhash = zend_register_internal_class_ex(&ce_intstringhash, php_qh_get_inthash_ce(), NULL TSRMLS_CC);
+#else
+	qh_ce_intstringhash = zend_register_internal_class_ex(&ce_intstringhash, php_qh_get_inthash_ce());
+	qh_ce_intstringhash->create_object = qh_object_new_intstringhash;
+#endif
 
 	qh_ce_intstringhash->get_iterator = qh_inthash_get_iterator;
 	qh_ce_intstringhash->iterator_funcs.funcs = &qh_inthash_it_funcs;
 
 	memcpy(&qh_object_handlers_intstringhash, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
-
+#if PHP_VERSION_ID < 70000
 	qh_add_constants(qh_ce_intstringhash TSRMLS_CC);
-
+#endif
 	zend_class_implements(qh_ce_intstringhash TSRMLS_CC, 1, zend_ce_arrayaccess);
 }
 
-static inline zend_object_value qh_object_new_intstringhash_ex(zend_class_entry *class_type, php_qh_intstringhash_obj **ptr TSRMLS_DC)
+static inline ZEND_OBJECT_VALUE_PTR qh_object_new_intstringhash_ex(zend_class_entry *class_type, php_qh_intstringhash_obj **ptr TSRMLS_DC)
 {
 	php_qh_intstringhash_obj *intern;
+#if PHP_VERSION_ID < 70000
 	zend_object_value retval;
 	zval *tmp;
 
 	intern = emalloc(sizeof(php_qh_intstringhash_obj));
 	memset(intern, 0, sizeof(php_qh_intstringhash_obj));
+#else
+	intern = ecalloc(1, sizeof(php_qh_intstringhash_obj) + zend_object_properties_size(class_type));
+#endif
 	if (ptr) {
 		*ptr = intern;
 	}
 
 	zend_object_std_init(&intern->std, class_type TSRMLS_CC);
-#if PHP_MINOR_VERSION > 3
 	object_properties_init(&intern->std, class_type);
-#else
-	zend_hash_copy(intern->std.properties, &class_type->default_properties, (copy_ctor_func_t) zval_add_ref, (void *) &tmp, sizeof(zval *));
-#endif
-
+#if PHP_VERSION_ID < 70000
 	retval.handle = zend_objects_store_put(intern, (zend_objects_store_dtor_t)zend_objects_destroy_object, (zend_objects_free_object_storage_t) qh_object_free_storage_intstringhash, NULL TSRMLS_CC);
 	retval.handlers = &qh_object_handlers_intstringhash;
 
 	return retval;
+#else
+	qh_object_handlers_intstringhash.offset = XtOffsetOf(php_qh_intstringhash_obj, std);
+	qh_object_handlers_intstringhash.dtor_obj = zend_objects_destroy_object;
+	qh_object_handlers_intstringhash.free_obj = qh_object_free_storage_intstringhash;
+	intern->std.handlers = &qh_object_handlers_intstringhash;
+
+	return &intern->std;
+#endif
 }
 
-static zend_object_value qh_object_new_intstringhash(zend_class_entry *class_type TSRMLS_DC)
+static ZEND_OBJECT_VALUE_PTR qh_object_new_intstringhash(zend_class_entry *class_type TSRMLS_DC)
 {
 	return qh_object_new_intstringhash_ex(class_type, NULL TSRMLS_CC);
 }
 
-static void qh_object_free_storage_intstringhash(void *object TSRMLS_DC)
+static void qh_object_free_storage_intstringhash(ZEND_OBJECT_PTR object TSRMLS_DC)
 {
-	php_qh_intstringhash_obj *intern = (php_qh_intstringhash_obj *) object;
+	php_qh_intstringhash_obj *intern = Z_QH_INTSTRINGHASH_OBJ(object);
 
 	if (intern->hash) {
 		qho *tmp_options = intern->hash->options;
@@ -176,11 +200,13 @@ static void qh_object_free_storage_intstringhash(void *object TSRMLS_DC)
 	}
 
 	zend_object_std_dtor(&intern->std TSRMLS_CC);
+#if PHP_VERSION_ID < 70000
 	efree(object);
+#endif
 }
 
 
-static int qh_intstringhash_initialize(php_qh_intset_obj *obj, long size, long flags TSRMLS_DC)
+static int qh_intstringhash_initialize(php_qh_intstringhash_obj *obj, long size, long flags TSRMLS_DC)
 {
 	qho *options = qho_create();
 
@@ -206,7 +232,7 @@ PHP_METHOD(QuickHashIntStringHash, __construct)
 	zend_error_handling error_handling;
 	zend_replace_error_handling(EH_THROW, NULL, &error_handling TSRMLS_CC);
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l|l", &size, &flags) == SUCCESS) {
-		if (!qh_intstringhash_initialize(zend_object_store_get_object(getThis() TSRMLS_CC), size, flags TSRMLS_CC)) {
+		if (!qh_intstringhash_initialize(Z_QH_INTSTRINGHASH_OBJ_P(getThis() TSRMLS_CC), size, flags TSRMLS_CC)) {
 			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Could not initialize hash.");
 		}
 	}
@@ -222,12 +248,12 @@ PHP_METHOD(QuickHashIntStringHash, add)
 	php_qh_intstringhash_obj *intstringhash_obj;
 	long               key;
 	char              *value;
-	long               value_len;
+	size_t               value_len;
 
 	if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "Ols", &object, qh_ce_intstringhash, &key, &value, &value_len) == FAILURE) {
 		RETURN_FALSE;
 	}
-	intstringhash_obj = (php_qh_intstringhash_obj *) zend_object_store_get_object(object TSRMLS_CC);
+	intstringhash_obj = Z_QH_INTSTRINGHASH_OBJ_P(object TSRMLS_CC);
 	RETURN_BOOL(qhi_hash_add(intstringhash_obj->hash, (qhv) (int32_t) key, (qhv) value));
 }
 /* }}} */
@@ -240,12 +266,12 @@ PHP_METHOD(QuickHashIntStringHash, set)
 	php_qh_intstringhash_obj *intstringhash_obj;
 	long                key;
 	char              *value;
-	long               value_len;
+	size_t               value_len;
 
 	if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "Ols", &object, qh_ce_intstringhash, &key, &value, &value_len) == FAILURE) {
 		RETURN_FALSE;
 	}
-	intstringhash_obj = (php_qh_intstringhash_obj *) zend_object_store_get_object(object TSRMLS_CC);
+	intstringhash_obj = Z_QH_INTSTRINGHASH_OBJ_P(object TSRMLS_CC);
 	RETURN_LONG(qhi_hash_set(intstringhash_obj->hash, (qhv) (int32_t) key, (qhv) value));
 }
 /* }}} */
@@ -258,12 +284,12 @@ PHP_METHOD(QuickHashIntStringHash, update)
 	php_qh_intstringhash_obj *intstringhash_obj;
 	long                key;
 	char              *value;
-	long               value_len;
+	size_t               value_len;
 
 	if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "Ols", &object, qh_ce_intstringhash, &key, &value, &value_len) == FAILURE) {
 		RETURN_FALSE;
 	}
-	intstringhash_obj = (php_qh_intstringhash_obj *) zend_object_store_get_object(object TSRMLS_CC);
+	intstringhash_obj = Z_QH_INTSTRINGHASH_OBJ_P(object TSRMLS_CC);
 	RETURN_BOOL(qhi_hash_update(intstringhash_obj->hash, (qhv) (int32_t) key, (qhv) value));
 }
 /* }}} */
@@ -321,7 +347,7 @@ static uint32_t qh_intstringhash_initialize_from_file(php_qh_intstringhash_obj *
 PHP_METHOD(QuickHashIntStringHash, loadFromFile)
 {
 	char *filename;
-	int   filename_len;
+	size_t   filename_len;
 	long  size = 0, flags = 0;
 	php_stream *stream;
 
@@ -339,7 +365,7 @@ PHP_METHOD(QuickHashIntStringHash, loadFromFile)
 	qh_instantiate(qh_ce_intstringhash, return_value TSRMLS_CC);
 	stream = php_stream_open_wrapper(filename, "r", IGNORE_PATH | REPORT_ERRORS, NULL);
 	if (stream) {
-		qh_intstringhash_initialize_from_file(zend_object_store_get_object(return_value TSRMLS_CC), stream, size, flags TSRMLS_CC);
+		qh_intstringhash_initialize_from_file(Z_QH_INTSTRINGHASH_OBJ_P(return_value TSRMLS_CC), stream, size, flags TSRMLS_CC);
 		php_stream_close(stream);
 	}
 	zend_restore_error_handling(&error_handling TSRMLS_CC);
@@ -361,7 +387,7 @@ int qh_intstringhash_save_to_file(php_stream *stream, php_qh_intstringhash_obj *
 PHP_METHOD(QuickHashIntStringHash, saveToFile)
 {
 	char *filename;
-	int   filename_len;
+	size_t   filename_len;
 	zval              *object;
 	php_qh_intstringhash_obj *intstringhash_obj;
 	php_stream *stream;
@@ -377,7 +403,7 @@ PHP_METHOD(QuickHashIntStringHash, saveToFile)
 		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Filename cannot be empty");
 	}
 
-	intstringhash_obj = (php_qh_intstringhash_obj *) zend_object_store_get_object(object TSRMLS_CC);
+	intstringhash_obj = Z_QH_INTSTRINGHASH_OBJ_P(object TSRMLS_CC);
 	stream = php_stream_open_wrapper(filename, "w", IGNORE_PATH | REPORT_ERRORS, NULL);
 
 	if (stream) {
@@ -434,7 +460,7 @@ static uint32_t qh_intstringhash_initialize_from_string(php_qh_intstringhash_obj
 PHP_METHOD(QuickHashIntStringHash, loadFromString)
 {
 	char    *contents;
-	int      contents_len;
+	size_t      contents_len;
 	long     size = 0, flags = 0;
 
 	zend_error_handling error_handling;
@@ -445,7 +471,7 @@ PHP_METHOD(QuickHashIntStringHash, loadFromString)
 	}
 
 	qh_instantiate(qh_ce_intstringhash, return_value TSRMLS_CC);
-	qh_intstringhash_initialize_from_string(zend_object_store_get_object(return_value TSRMLS_CC), contents, contents_len, size, flags TSRMLS_CC);
+	qh_intstringhash_initialize_from_string(Z_QH_INTSTRINGHASH_OBJ_P(return_value TSRMLS_CC), contents, contents_len, size, flags TSRMLS_CC);
 	zend_restore_error_handling(&error_handling TSRMLS_CC);
 }
 /* }}} */
@@ -479,10 +505,15 @@ PHP_METHOD(QuickHashIntStringHash, saveToString)
 		return;
 	}
 
-	intstringhash_obj = (php_qh_intstringhash_obj *) zend_object_store_get_object(object TSRMLS_CC);
+	intstringhash_obj = Z_QH_INTSTRINGHASH_OBJ_P(object TSRMLS_CC);
 
 	string = qh_intstringhash_save_to_string(&string_len, intstringhash_obj);
 	zend_restore_error_handling(&error_handling TSRMLS_CC);
+#if PHP_VERSION_ID < 70000
 	RETURN_STRINGL(string, string_len, 0);
+#else
+	RETVAL_STRINGL(string, string_len);
+	efree(string);
+#endif
 }
 /* }}} */

--- a/qh_intstringhash.c
+++ b/qh_intstringhash.c
@@ -203,13 +203,14 @@ PHP_METHOD(QuickHashIntStringHash, __construct)
 	long size;
 	long flags = 0;
 
-	php_set_error_handling(EH_THROW, NULL TSRMLS_CC);
+	zend_error_handling error_handling;
+	zend_replace_error_handling(EH_THROW, NULL, &error_handling TSRMLS_CC);
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l|l", &size, &flags) == SUCCESS) {
 		if (!qh_intstringhash_initialize(zend_object_store_get_object(getThis() TSRMLS_CC), size, flags TSRMLS_CC)) {
 			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Could not initialize hash.");
 		}
 	}
-	php_set_error_handling(EH_NORMAL, NULL TSRMLS_CC);
+	zend_restore_error_handling(&error_handling TSRMLS_CC);
 }
 /* }}} */
 
@@ -323,8 +324,10 @@ PHP_METHOD(QuickHashIntStringHash, loadFromFile)
 	long  size = 0, flags = 0;
 	php_stream *stream;
 
-	php_set_error_handling(EH_THROW, NULL TSRMLS_CC);
+	zend_error_handling error_handling;
+	zend_replace_error_handling(EH_THROW, NULL, &error_handling TSRMLS_CC);
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|ll", &filename, &filename_len, &size, &flags) == FAILURE) {
+		zend_restore_error_handling(&error_handling TSRMLS_CC);
 		return;
 	}
 
@@ -338,7 +341,7 @@ PHP_METHOD(QuickHashIntStringHash, loadFromFile)
 		qh_intstringhash_initialize_from_file(zend_object_store_get_object(return_value TSRMLS_CC), stream, size, flags TSRMLS_CC);
 		php_stream_close(stream);
 	}
-	php_set_error_handling(EH_NORMAL, NULL TSRMLS_CC);
+	zend_restore_error_handling(&error_handling TSRMLS_CC);
 }
 /* }}} */
 
@@ -362,8 +365,10 @@ PHP_METHOD(QuickHashIntStringHash, saveToFile)
 	php_qh_intstringhash_obj *intstringhash_obj;
 	php_stream *stream;
 
-	php_set_error_handling(EH_THROW, NULL TSRMLS_CC);
+	zend_error_handling error_handling;
+	zend_replace_error_handling(EH_THROW, NULL, &error_handling TSRMLS_CC);
 	if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "Os", &object, qh_ce_intstringhash, &filename, &filename_len) == FAILURE) {
+		zend_restore_error_handling(&error_handling TSRMLS_CC);
 		return;
 	}
 
@@ -378,7 +383,7 @@ PHP_METHOD(QuickHashIntStringHash, saveToFile)
 		qh_intstringhash_save_to_file(stream, intstringhash_obj);
 		php_stream_close(stream);
 	}
-	php_set_error_handling(EH_NORMAL, NULL TSRMLS_CC);
+	zend_restore_error_handling(&error_handling TSRMLS_CC);
 }
 /* }}} */
 
@@ -431,14 +436,16 @@ PHP_METHOD(QuickHashIntStringHash, loadFromString)
 	int      contents_len;
 	long     size = 0, flags = 0;
 
-	php_set_error_handling(EH_THROW, NULL TSRMLS_CC);
+	zend_error_handling error_handling;
+	zend_replace_error_handling(EH_THROW, NULL, &error_handling TSRMLS_CC);
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|ll", &contents, &contents_len, &size, &flags) == FAILURE) {
+		zend_restore_error_handling(&error_handling TSRMLS_CC);
 		return;
 	}
 
 	qh_instantiate(qh_ce_intstringhash, return_value TSRMLS_CC);
 	qh_intstringhash_initialize_from_string(zend_object_store_get_object(return_value TSRMLS_CC), contents, contents_len, size, flags TSRMLS_CC);
-	php_set_error_handling(EH_NORMAL, NULL TSRMLS_CC);
+	zend_restore_error_handling(&error_handling TSRMLS_CC);
 }
 /* }}} */
 
@@ -464,15 +471,17 @@ PHP_METHOD(QuickHashIntStringHash, saveToString)
 	char              *string;
 	uint32_t           string_len;
 
-	php_set_error_handling(EH_THROW, NULL TSRMLS_CC);
+	zend_error_handling error_handling;
+	zend_replace_error_handling(EH_THROW, NULL, &error_handling TSRMLS_CC);
 	if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "O", &object, qh_ce_intstringhash) == FAILURE) {
+		zend_restore_error_handling(&error_handling TSRMLS_CC);
 		return;
 	}
 
 	intstringhash_obj = (php_qh_intstringhash_obj *) zend_object_store_get_object(object TSRMLS_CC);
 
 	string = qh_intstringhash_save_to_string(&string_len, intstringhash_obj);
-	php_set_error_handling(EH_NORMAL, NULL TSRMLS_CC);
+	zend_restore_error_handling(&error_handling TSRMLS_CC);
 	RETURN_STRINGL(string, string_len, 0);
 }
 /* }}} */

--- a/qh_intstringhash.c
+++ b/qh_intstringhash.c
@@ -152,10 +152,10 @@ static inline zend_object_value qh_object_new_intstringhash_ex(zend_class_entry 
 #else
 	zend_hash_copy(intern->std.properties, &class_type->default_properties, (copy_ctor_func_t) zval_add_ref, (void *) &tmp, sizeof(zval *));
 #endif
-	
+
 	retval.handle = zend_objects_store_put(intern, (zend_objects_store_dtor_t)zend_objects_destroy_object, (zend_objects_free_object_storage_t) qh_object_free_storage_intstringhash, NULL TSRMLS_CC);
 	retval.handlers = &qh_object_handlers_intstringhash;
-	
+
 	return retval;
 }
 
@@ -271,6 +271,7 @@ PHP_METHOD(QuickHashIntStringHash, update)
 /* Validates whether the stream is in the correct format */
 static int qh_intstringhash_stream_validator(php_stream_statbuf finfo, php_stream *stream, uint32_t *nr_of_elements, uint32_t *value_array_length)
 {
+	TSRMLS_FETCH();
 	char key_buffer[4];
 	uint32_t hash_size;
 	uint32_t string_store_size;

--- a/qh_intstringhash.h
+++ b/qh_intstringhash.h
@@ -21,12 +21,12 @@
 #define PHP_QUICKHASH_INTSTRINGHASH_H
 
 #include "lib/quickhash.h"
+#include "quickhash.h"
 
 typedef struct _php_qh_intstringhash_obj php_qh_intstringhash_obj;
 
 struct _php_qh_intstringhash_obj {
-	zend_object   std;
-	qhi          *hash;
+	QH_PHP_OBJ
 };
 
 PHP_METHOD(QuickHashIntStringHash, __construct);

--- a/qh_iterator.c
+++ b/qh_iterator.c
@@ -103,18 +103,15 @@ static void qh_intset_it_current_data(zend_object_iterator *iter, zval ***data T
 	*data = &iterator->current_value;
 }
 
-static int qh_intset_it_current_key(zend_object_iterator *iter, char **str_key, uint *str_key_len, ulong *int_key TSRMLS_DC)
+static void qh_intset_it_current_key(zend_object_iterator *iter, zval *key TSRMLS_DC)
 {
 	qh_intset_it *iterator = (qh_intset_it *)iter;
 	qhi          *hash = (qhi* ) iterator->intern.data;
 
 	if (hash->key_type == QHI_KEY_TYPE_STRING) {
-		*str_key = estrndup(hash->keys.values + iterator->iterator.key, strlen(hash->keys.values + iterator->iterator.key));
-		*str_key_len = strlen(*str_key) + 1;
-		return HASH_KEY_IS_STRING;
+		ZVAL_STRINGL(key, hash->keys.values + iterator->iterator.key, strlen(hash->keys.values + iterator->iterator.key), 1);
 	} else {
-		*int_key = iterator->iterator.key;
-		return HASH_KEY_IS_LONG;
+		ZVAL_LONG(key, iterator->iterator.key);
 	}
 }
 #else

--- a/qh_iterator.c
+++ b/qh_iterator.c
@@ -44,7 +44,6 @@ static void qh_intset_it_dtor(zend_object_iterator *iter TSRMLS_DC)
 #endif
 	qhi_iterator_deinit(&iterator->iterator);
 #if PHP_VERSION_ID < 70000
-	qhi_iterator_deinit(&iterator->iterator);
 	zval_ptr_dtor(&iterator->current_value);
 	efree(iterator);
 #else
@@ -106,7 +105,7 @@ static void qh_intset_it_current_data(zend_object_iterator *iter, zval ***data T
 static void qh_intset_it_current_key(zend_object_iterator *iter, zval *key TSRMLS_DC)
 {
 	qh_intset_it *iterator = (qh_intset_it *)iter;
-	qhi          *hash = (qhi* ) iterator->intern.data;
+	qhi          *hash     = (qhi* )iterator->intern.data;
 
 	if (hash->key_type == QHI_KEY_TYPE_STRING) {
 		ZVAL_STRINGL(key, hash->keys.values + iterator->iterator.key, strlen(hash->keys.values + iterator->iterator.key), 1);

--- a/qh_iterator.c
+++ b/qh_iterator.c
@@ -30,18 +30,28 @@ typedef struct {
 	zend_object_iterator  intern;
 	zval                 *current_value;
 	qhit                  iterator;
+#if PHP_VERSION_ID < 70000
 	zval                 *object_ref; /* Used so that we can protect the object from being destroyed prematurely */
+#endif
 } qh_intset_it;
 
 /* iterator handlers */
 static void qh_intset_it_dtor(zend_object_iterator *iter TSRMLS_DC)
 {
 	qh_intset_it *iterator = (qh_intset_it *)iter;
-
+#if PHP_VERSION_ID < 70000
 	Z_DELREF_P(iterator->object_ref);
+#endif
+	qhi_iterator_deinit(&iterator->iterator);
+#if PHP_VERSION_ID < 70000
 	qhi_iterator_deinit(&iterator->iterator);
 	zval_ptr_dtor(&iterator->current_value);
 	efree(iterator);
+#else
+	zval_ptr_dtor(&iterator->intern.data);
+	zval_ptr_dtor(iterator->current_value);
+	efree(iterator->current_value);
+#endif
 }
 
 static int qh_intset_it_has_more(zend_object_iterator *iter TSRMLS_DC)
@@ -59,7 +69,11 @@ static int qh_inthash_it_has_more(zend_object_iterator *iter TSRMLS_DC)
 {
 	qh_intset_it *iterator = (qh_intset_it *)iter;
 	int            ret;
+#if PHP_VERSION_ID < 70000
 	qhi           *hash = (qhi* ) iterator->intern.data;
+#else
+	qhi           *hash = Z_QH_INTSET_OBJ_P(&iterator->intern.data)->hash;
+#endif
 
 	ret = qhi_iterator_forward(&iterator->iterator) ? SUCCESS : FAILURE;
 	switch (hash->value_type) {
@@ -70,13 +84,18 @@ static int qh_inthash_it_has_more(zend_object_iterator *iter TSRMLS_DC)
 			if (Z_TYPE_P(iterator->current_value) == IS_STRING) {
 				zval_dtor(iterator->current_value);
 			}
+#if PHP_VERSION_ID < 70000
 			ZVAL_STRING(iterator->current_value, iterator->iterator.value.s, 1);
+#else
+			ZVAL_STRING(iterator->current_value, iterator->iterator.value.s);
+#endif
 			break;
 	}
 
 	return ret;
 }
 
+#if PHP_VERSION_ID < 70000
 static void qh_intset_it_current_data(zend_object_iterator *iter, zval ***data TSRMLS_DC)
 {
 	qh_intset_it *iterator = (qh_intset_it *)iter;
@@ -98,6 +117,24 @@ static int qh_intset_it_current_key(zend_object_iterator *iter, char **str_key, 
 		return HASH_KEY_IS_LONG;
 	}
 }
+#else
+static zval* qh_intset_it_current_data(zend_object_iterator *iter)
+{
+	return ((qh_intset_it *)iter)->current_value;
+}
+
+static void qh_intset_it_current_key(zend_object_iterator *iter, zval *key)
+{
+	qh_intset_it *iterator = (qh_intset_it *)iter;
+	qhi          *hash = Z_QH_INTSET_OBJ_P(&iterator->intern.data)->hash;
+
+	if (hash->key_type == QHI_KEY_TYPE_STRING) {
+        ZVAL_STRINGL(key, hash->keys.values + iterator->iterator.key, strlen(hash->keys.values + iterator->iterator.key));
+	} else {
+        ZVAL_LONG(key, iterator->iterator.key);
+	}
+}
+#endif
 
 static void qh_intset_it_move_forward(zend_object_iterator *iter TSRMLS_DC)
 {
@@ -106,9 +143,11 @@ static void qh_intset_it_move_forward(zend_object_iterator *iter TSRMLS_DC)
 static void qh_intset_it_rewind(zend_object_iterator *iter TSRMLS_DC)
 {
 	qh_intset_it *iterator = (qh_intset_it *)iter;
-	qhi           *hash = (qhi* ) iterator->intern.data;
-
-	qhi_iterator_init(&iterator->iterator, hash);
+#if PHP_VERSION_ID < 70000
+	qhi_iterator_init(&iterator->iterator, (qhi*)iterator->intern.data);
+#else
+	qhi_iterator_init(&iterator->iterator, Z_QH_INTSET_OBJ_P(&iterator->intern.data)->hash);
+#endif
 }
 
 /* iterator handler table for sets */
@@ -125,21 +164,34 @@ zend_object_iterator_funcs qh_intset_it_funcs = {
 zend_object_iterator *qh_intset_get_iterator(zend_class_entry *ce, zval *object, int by_ref TSRMLS_DC)
 {
 	qh_intset_it  *iterator = emalloc(sizeof(qh_intset_it));
+#if PHP_VERSION_ID < 70000
 	php_qh_intset_obj  *obj    = (php_qh_intset_obj *)zend_object_store_get_object(object TSRMLS_CC);
+#endif
 
 	if (by_ref) {
 		zend_error(E_ERROR, "An iterator cannot be used with foreach by reference");
 	}
-
+#if PHP_VERSION_ID < 70000
 	iterator->intern.data = (void*) obj->hash;
+#else
+	zend_iterator_init(&iterator->intern);
+	ZVAL_COPY(&iterator->intern.data, object);
+#endif
 	iterator->intern.funcs = &qh_intset_it_funcs;
+#if PHP_VERSION_ID < 70000
 	iterator->object_ref = object;
 	Z_ADDREF_P(iterator->object_ref);
 
 	MAKE_STD_ZVAL(iterator->current_value);
+#else
+	iterator->current_value = emalloc(sizeof(zval));
+#endif
 	ZVAL_NULL(iterator->current_value);
-
+#if PHP_VERSION_ID < 70000
 	return (zend_object_iterator*)iterator;
+#else
+	return &iterator->intern;
+#endif
 }
 
 /* iterator handler table for hashes */
@@ -156,19 +208,33 @@ zend_object_iterator_funcs qh_inthash_it_funcs = {
 zend_object_iterator *qh_inthash_get_iterator(zend_class_entry *ce, zval *object, int by_ref TSRMLS_DC)
 {
 	qh_intset_it  *iterator = emalloc(sizeof(qh_intset_it));
+#if PHP_VERSION_ID < 70000
 	php_qh_intset_obj  *obj    = (php_qh_intset_obj *)zend_object_store_get_object(object TSRMLS_CC);
+#endif
 
 	if (by_ref) {
 		zend_error(E_ERROR, "An iterator cannot be used with foreach by reference");
 	}
 
+#if PHP_VERSION_ID < 70000
 	iterator->intern.data = (void*) obj->hash;
+#else
+	zend_iterator_init(&iterator->intern);
+	ZVAL_COPY(&iterator->intern.data, object);
+#endif
 	iterator->intern.funcs = &qh_inthash_it_funcs;
+#if PHP_VERSION_ID < 70000
 	iterator->object_ref = object;
 	Z_ADDREF_P(iterator->object_ref);
 
 	MAKE_STD_ZVAL(iterator->current_value);
+#else
+	iterator->current_value = emalloc(sizeof(zval));
+#endif
 	ZVAL_NULL(iterator->current_value);
-
+#if PHP_VERSION_ID < 70000
 	return (zend_object_iterator*)iterator;
+#else
+	return &iterator->intern;
+#endif
 }

--- a/qh_stringinthash.c
+++ b/qh_stringinthash.c
@@ -152,10 +152,10 @@ static inline zend_object_value qh_object_new_stringinthash_ex(zend_class_entry 
 #else
 	zend_hash_copy(intern->std.properties, &class_type->default_properties, (copy_ctor_func_t) zval_add_ref, (void *) &tmp, sizeof(zval *));
 #endif
-	
+
 	retval.handle = zend_objects_store_put(intern, (zend_objects_store_dtor_t)zend_objects_destroy_object, (zend_objects_free_object_storage_t) qh_object_free_storage_stringinthash, NULL TSRMLS_CC);
 	retval.handlers = &qh_object_handlers_stringinthash;
-	
+
 	return retval;
 }
 
@@ -330,6 +330,7 @@ PHP_METHOD(QuickHashStringIntHash, delete)
 /* Validates whether the stream is in the correct format */
 static int qh_stringinthash_stream_validator(php_stream_statbuf finfo, php_stream *stream, uint32_t *nr_of_elements, uint32_t *value_array_length)
 {
+	TSRMLS_FETCH();
 	char key_buffer[4];
 	uint32_t hash_size;
 	uint32_t string_store_size;

--- a/qh_stringinthash.c
+++ b/qh_stringinthash.c
@@ -203,13 +203,14 @@ PHP_METHOD(QuickHashStringIntHash, __construct)
 	long size;
 	long flags = 0;
 
-	php_set_error_handling(EH_THROW, NULL TSRMLS_CC);
+	zend_error_handling error_handling;
+	zend_replace_error_handling(EH_THROW, NULL, &error_handling TSRMLS_CC);
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l|l", &size, &flags) == SUCCESS) {
 		if (!qh_stringinthash_initialize(zend_object_store_get_object(getThis() TSRMLS_CC), size, flags TSRMLS_CC)) {
 			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Could not initialize hash.");
 		}
 	}
-	php_set_error_handling(EH_NORMAL, NULL TSRMLS_CC);
+	zend_restore_error_handling(&error_handling TSRMLS_CC);
 }
 /* }}} */
 
@@ -382,8 +383,10 @@ PHP_METHOD(QuickHashStringIntHash, loadFromFile)
 	long  size = 0, flags = 0;
 	php_stream *stream;
 
-	php_set_error_handling(EH_THROW, NULL TSRMLS_CC);
+	zend_error_handling error_handling;
+	zend_replace_error_handling(EH_THROW, NULL, &error_handling TSRMLS_CC);
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|ll", &filename, &filename_len, &size, &flags) == FAILURE) {
+		zend_restore_error_handling(&error_handling TSRMLS_CC);
 		return;
 	}
 
@@ -397,7 +400,7 @@ PHP_METHOD(QuickHashStringIntHash, loadFromFile)
 		qh_stringinthash_initialize_from_file(zend_object_store_get_object(return_value TSRMLS_CC), stream, size, flags TSRMLS_CC);
 		php_stream_close(stream);
 	}
-	php_set_error_handling(EH_NORMAL, NULL TSRMLS_CC);
+	zend_restore_error_handling(&error_handling TSRMLS_CC);
 }
 /* }}} */
 
@@ -421,8 +424,10 @@ PHP_METHOD(QuickHashStringIntHash, saveToFile)
 	php_qh_stringinthash_obj *stringinthash_obj;
 	php_stream *stream;
 
-	php_set_error_handling(EH_THROW, NULL TSRMLS_CC);
+	zend_error_handling error_handling;
+	zend_replace_error_handling(EH_THROW, NULL, &error_handling TSRMLS_CC);
 	if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "Os", &object, qh_ce_stringinthash, &filename, &filename_len) == FAILURE) {
+		zend_restore_error_handling(&error_handling TSRMLS_CC);
 		return;
 	}
 
@@ -437,7 +442,7 @@ PHP_METHOD(QuickHashStringIntHash, saveToFile)
 		qh_stringinthash_save_to_file(stream, stringinthash_obj);
 		php_stream_close(stream);
 	}
-	php_set_error_handling(EH_NORMAL, NULL TSRMLS_CC);
+	zend_restore_error_handling(&error_handling TSRMLS_CC);
 }
 /* }}} */
 
@@ -488,14 +493,16 @@ PHP_METHOD(QuickHashStringIntHash, loadFromString)
 	int      contents_len;
 	long     size = 0, flags = 0;
 
-	php_set_error_handling(EH_THROW, NULL TSRMLS_CC);
+	zend_error_handling error_handling;
+	zend_replace_error_handling(EH_THROW, NULL, &error_handling TSRMLS_CC);
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|ll", &contents, &contents_len, &size, &flags) == FAILURE) {
+		zend_restore_error_handling(&error_handling TSRMLS_CC);
 		return;
 	}
 
 	qh_instantiate(qh_ce_stringinthash, return_value TSRMLS_CC);
 	qh_stringinthash_initialize_from_string(zend_object_store_get_object(return_value TSRMLS_CC), contents, contents_len, size, flags TSRMLS_CC);
-	php_set_error_handling(EH_NORMAL, NULL TSRMLS_CC);
+	zend_restore_error_handling(&error_handling TSRMLS_CC);
 }
 /* }}} */
 
@@ -521,15 +528,17 @@ PHP_METHOD(QuickHashStringIntHash, saveToString)
 	char              *string;
 	uint32_t           string_len;
 
-	php_set_error_handling(EH_THROW, NULL TSRMLS_CC);
+	zend_error_handling error_handling;
+	zend_replace_error_handling(EH_THROW, NULL, &error_handling TSRMLS_CC);
 	if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "O", &object, qh_ce_stringinthash) == FAILURE) {
+		zend_restore_error_handling(&error_handling TSRMLS_CC);
 		return;
 	}
 
 	stringinthash_obj = (php_qh_stringinthash_obj *) zend_object_store_get_object(object TSRMLS_CC);
 
 	string = qh_stringinthash_save_to_string(&string_len, stringinthash_obj);
-	php_set_error_handling(EH_NORMAL, NULL TSRMLS_CC);
+	zend_restore_error_handling(&error_handling TSRMLS_CC);
 	RETURN_STRINGL(string, string_len, 0);
 }
 /* }}} */

--- a/qh_stringinthash.c
+++ b/qh_stringinthash.c
@@ -228,10 +228,10 @@ static int qh_stringinthash_initialize(php_qh_stringinthash_obj *obj, long size,
    Creates a new QuickHashStringIntHash */
 PHP_METHOD(QuickHashStringIntHash, __construct)
 {
-	long size;
-	long flags = 0;
-
+	long                size;
+	long                flags = 0;
 	zend_error_handling error_handling;
+
 	zend_replace_error_handling(EH_THROW, NULL, &error_handling TSRMLS_CC);
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l|l", &size, &flags) == SUCCESS) {
 		if (!qh_stringinthash_initialize(Z_QH_STRINGINTHASH_OBJ_P(getThis() TSRMLS_CC), size, flags TSRMLS_CC)) {
@@ -246,11 +246,11 @@ PHP_METHOD(QuickHashStringIntHash, __construct)
    Adds an element with key key and value value to the hash */
 PHP_METHOD(QuickHashStringIntHash, add)
 {
-	zval              *object;
+	zval                     *object;
 	php_qh_stringinthash_obj *stringinthash_obj;
-	char              *key;
-	TYPE_ARG_L               key_len;
-	long               value;
+	char                     *key;
+	TYPE_ARG_L                key_len;
+	long                      value;
 
 	if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "Osl", &object, qh_ce_stringinthash, &key, &key_len, &value) == FAILURE) {
 		RETURN_FALSE;
@@ -264,10 +264,10 @@ PHP_METHOD(QuickHashStringIntHash, add)
    Tests whether the element with key key is part of the set */
 PHP_METHOD(QuickHashStringIntHash, exists)
 {
-	zval              *object;
+	zval                     *object;
 	php_qh_stringinthash_obj *intset_obj;
-	char              *key;
-	TYPE_ARG_L               key_len;
+	char                     *key;
+	TYPE_ARG_L                key_len;
 
 	if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "Os", &object, qh_ce_stringinthash, &key, &key_len) == FAILURE) {
 		RETURN_FALSE;
@@ -281,11 +281,11 @@ PHP_METHOD(QuickHashStringIntHash, exists)
    Returns a value belonging to a key */
 PHP_METHOD(QuickHashStringIntHash, get)
 {
-	zval               *object;
+	zval                     *object;
 	php_qh_stringinthash_obj *stringinthash_obj;
-	char               *key;
+	char                     *key;
 	TYPE_ARG_L                key_len;
-	qhv                 value;
+	qhv                       value;
 
 	if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "Os", &object, qh_ce_stringinthash, &key, &key_len) == FAILURE) {
 		RETURN_FALSE;
@@ -310,11 +310,11 @@ PHP_METHOD(QuickHashStringIntHash, get)
    Updates the value of an element if it exists, or otherwise adds a new element */
 PHP_METHOD(QuickHashStringIntHash, set)
 {
-	zval               *object;
+	zval                     *object;
 	php_qh_stringinthash_obj *stringinthash_obj;
-	char               *key;
+	char                     *key;
 	TYPE_ARG_L                key_len;
-	long                value;
+	long                      value;
 
 	if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "Osl", &object, qh_ce_stringinthash, &key, &key_len, &value) == FAILURE) {
 		RETURN_FALSE;
@@ -328,11 +328,11 @@ PHP_METHOD(QuickHashStringIntHash, set)
    Updates the value of an element for key key */
 PHP_METHOD(QuickHashStringIntHash, update)
 {
-	zval              *object;
+	zval                     *object;
 	php_qh_stringinthash_obj *stringinthash_obj;
-	char               *key;
+	char                     *key;
 	TYPE_ARG_L                key_len;
-	long                value;
+	long                      value;
 
 	if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "Osl", &object, qh_ce_stringinthash, &key, &key_len, &value) == FAILURE) {
 		RETURN_FALSE;
@@ -346,9 +346,9 @@ PHP_METHOD(QuickHashStringIntHash, update)
    Deletes an entry with the key from the set */
 PHP_METHOD(QuickHashStringIntHash, delete)
 {
-	zval              *object;
+	zval                     *object;
 	php_qh_stringinthash_obj *intset_obj;
-	char               *key;
+	char                     *key;
 	TYPE_ARG_L                key_len;
 
 	if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "Os", &object, qh_ce_stringinthash, &key, &key_len) == FAILURE) {
@@ -411,12 +411,12 @@ static uint32_t qh_stringinthash_initialize_from_file(php_qh_stringinthash_obj *
    Creates a QuickHashStringIntHash from data in file filename */
 PHP_METHOD(QuickHashStringIntHash, loadFromFile)
 {
-	char *filename;
-	TYPE_ARG_L   filename_len;
-	long  size = 0, flags = 0;
-	php_stream *stream;
-
+	char               *filename;
+	TYPE_ARG_L          filename_len;
+	long                size = 0, flags = 0;
+	php_stream         *stream;
 	zend_error_handling error_handling;
+
 	zend_replace_error_handling(EH_THROW, NULL, &error_handling TSRMLS_CC);
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|ll", &filename, &filename_len, &size, &flags) == FAILURE) {
 		zend_restore_error_handling(&error_handling TSRMLS_CC);
@@ -451,13 +451,13 @@ int qh_stringinthash_save_to_file(php_stream *stream, php_qh_stringinthash_obj *
    Saves the hash to a file */
 PHP_METHOD(QuickHashStringIntHash, saveToFile)
 {
-	char *filename;
-	TYPE_ARG_L   filename_len;
-	zval              *object;
+	char                     *filename;
+	TYPE_ARG_L                filename_len;
+	zval                     *object;
 	php_qh_stringinthash_obj *stringinthash_obj;
-	php_stream *stream;
+	php_stream               *stream;
+	zend_error_handling       error_handling;
 
-	zend_error_handling error_handling;
 	zend_replace_error_handling(EH_THROW, NULL, &error_handling TSRMLS_CC);
 	if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "Os", &object, qh_ce_stringinthash, &filename, &filename_len) == FAILURE) {
 		zend_restore_error_handling(&error_handling TSRMLS_CC);
@@ -518,11 +518,11 @@ static uint32_t qh_stringinthash_initialize_from_string(php_qh_stringinthash_obj
    Creates a QuickHashStringIntHash from data in a string */
 PHP_METHOD(QuickHashStringIntHash, loadFromString)
 {
-	char    *contents;
-	TYPE_ARG_L      contents_len;
-	long     size = 0, flags = 0;
-
+	char               *contents;
+	TYPE_ARG_L          contents_len;
+	long                size = 0, flags = 0;
 	zend_error_handling error_handling;
+
 	zend_replace_error_handling(EH_THROW, NULL, &error_handling TSRMLS_CC);
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|ll", &contents, &contents_len, &size, &flags) == FAILURE) {
 		zend_restore_error_handling(&error_handling TSRMLS_CC);
@@ -552,12 +552,12 @@ char *qh_stringinthash_save_to_string(uint32_t *string_len, php_qh_stringinthash
    Returns the hash as a string */
 PHP_METHOD(QuickHashStringIntHash, saveToString)
 {
-	zval              *object;
+	zval                     *object;
 	php_qh_stringinthash_obj *stringinthash_obj;
-	char              *string;
-	uint32_t           string_len;
+	char                     *string;
+	uint32_t                  string_len;
+	zend_error_handling       error_handling;
 
-	zend_error_handling error_handling;
 	zend_replace_error_handling(EH_THROW, NULL, &error_handling TSRMLS_CC);
 	if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "O", &object, qh_ce_stringinthash) == FAILURE) {
 		zend_restore_error_handling(&error_handling TSRMLS_CC);

--- a/qh_stringinthash.c
+++ b/qh_stringinthash.c
@@ -249,7 +249,7 @@ PHP_METHOD(QuickHashStringIntHash, add)
 	zval              *object;
 	php_qh_stringinthash_obj *stringinthash_obj;
 	char              *key;
-	size_t               key_len;
+	TYPE_ARG_L               key_len;
 	long               value;
 
 	if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "Osl", &object, qh_ce_stringinthash, &key, &key_len, &value) == FAILURE) {
@@ -267,7 +267,7 @@ PHP_METHOD(QuickHashStringIntHash, exists)
 	zval              *object;
 	php_qh_stringinthash_obj *intset_obj;
 	char              *key;
-	size_t               key_len;
+	TYPE_ARG_L               key_len;
 
 	if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "Os", &object, qh_ce_stringinthash, &key, &key_len) == FAILURE) {
 		RETURN_FALSE;
@@ -284,7 +284,7 @@ PHP_METHOD(QuickHashStringIntHash, get)
 	zval               *object;
 	php_qh_stringinthash_obj *stringinthash_obj;
 	char               *key;
-	size_t                key_len;
+	TYPE_ARG_L                key_len;
 	qhv                 value;
 
 	if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "Os", &object, qh_ce_stringinthash, &key, &key_len) == FAILURE) {
@@ -313,7 +313,7 @@ PHP_METHOD(QuickHashStringIntHash, set)
 	zval               *object;
 	php_qh_stringinthash_obj *stringinthash_obj;
 	char               *key;
-	size_t                key_len;
+	TYPE_ARG_L                key_len;
 	long                value;
 
 	if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "Osl", &object, qh_ce_stringinthash, &key, &key_len, &value) == FAILURE) {
@@ -331,7 +331,7 @@ PHP_METHOD(QuickHashStringIntHash, update)
 	zval              *object;
 	php_qh_stringinthash_obj *stringinthash_obj;
 	char               *key;
-	size_t                key_len;
+	TYPE_ARG_L                key_len;
 	long                value;
 
 	if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "Osl", &object, qh_ce_stringinthash, &key, &key_len, &value) == FAILURE) {
@@ -349,7 +349,7 @@ PHP_METHOD(QuickHashStringIntHash, delete)
 	zval              *object;
 	php_qh_stringinthash_obj *intset_obj;
 	char               *key;
-	size_t                key_len;
+	TYPE_ARG_L                key_len;
 
 	if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "Os", &object, qh_ce_stringinthash, &key, &key_len) == FAILURE) {
 		RETURN_FALSE;
@@ -412,7 +412,7 @@ static uint32_t qh_stringinthash_initialize_from_file(php_qh_stringinthash_obj *
 PHP_METHOD(QuickHashStringIntHash, loadFromFile)
 {
 	char *filename;
-	size_t   filename_len;
+	TYPE_ARG_L   filename_len;
 	long  size = 0, flags = 0;
 	php_stream *stream;
 
@@ -452,7 +452,7 @@ int qh_stringinthash_save_to_file(php_stream *stream, php_qh_stringinthash_obj *
 PHP_METHOD(QuickHashStringIntHash, saveToFile)
 {
 	char *filename;
-	size_t   filename_len;
+	TYPE_ARG_L   filename_len;
 	zval              *object;
 	php_qh_stringinthash_obj *stringinthash_obj;
 	php_stream *stream;
@@ -519,7 +519,7 @@ static uint32_t qh_stringinthash_initialize_from_string(php_qh_stringinthash_obj
 PHP_METHOD(QuickHashStringIntHash, loadFromString)
 {
 	char    *contents;
-	size_t      contents_len;
+	TYPE_ARG_L      contents_len;
 	long     size = 0, flags = 0;
 
 	zend_error_handling error_handling;

--- a/qh_stringinthash.h
+++ b/qh_stringinthash.h
@@ -21,12 +21,12 @@
 #define PHP_QUICKHASH_STRINGINTHASH_H
 
 #include "lib/quickhash.h"
+#include "quickhash.h"
 
 typedef struct _php_qh_stringinthash_obj php_qh_stringinthash_obj;
 
 struct _php_qh_stringinthash_obj {
-	zend_object   std;
-	qhi          *hash;
+	QH_PHP_OBJ
 };
 
 PHP_METHOD(QuickHashStringIntHash, __construct);

--- a/quickhash.c
+++ b/quickhash.c
@@ -48,7 +48,7 @@ zend_module_entry quickhash_module_entry = {
 	quickhash_functions,
 	PHP_MINIT(quickhash),
 	PHP_MSHUTDOWN(quickhash),
-	PHP_RINIT(quickhash),	
+	PHP_RINIT(quickhash),
 	PHP_RSHUTDOWN(quickhash),
 	PHP_MINFO(quickhash),
 #if ZEND_MODULE_API_NO >= 20010901
@@ -59,6 +59,9 @@ zend_module_entry quickhash_module_entry = {
 
 
 #ifdef COMPILE_DL_QUICKHASH
+#if defined(ZTS) && PHP_VERSION_ID >= 70000
+	ZEND_TSRMLS_CACHE_DEFINE();
+#endif
 ZEND_GET_MODULE(quickhash)
 #endif
 
@@ -67,7 +70,7 @@ ZEND_DECLARE_MODULE_GLOBALS(quickhash)
 PHP_INI_BEGIN()
 PHP_INI_END()
 */
- 
+
 static void quickhash_init_globals(zend_quickhash_globals *quickhash_globals)
 {
 	/* Empty */
@@ -157,7 +160,7 @@ int php_qh_load_int32t_from_string_func(void *context, int32_t *buffer, uint32_t
 #if 0
 printf("req: %d; pos: %d : length: %d, max: %d\n",
 	elements * sizeof(int32_t),
-	ctxt->ptr - ctxt->string, 
+	ctxt->ptr - ctxt->string,
 	ctxt->string_len, (ctxt->string_len - (ctxt->ptr - ctxt->string)));
 #endif
 	req = elements * sizeof(int32_t);
@@ -207,6 +210,7 @@ int php_qh_save_chars_to_string_func(void *context, char *buffer, uint32_t eleme
 
 int32_t php_qh_get_size_from_stream(void *context)
 {
+	TSRMLS_FETCH();
 	php_qh_stream_context *ctxt = (php_qh_stream_context*) context;
 	php_stream_statbuf     finfo;
 
@@ -331,6 +335,9 @@ PHP_MSHUTDOWN_FUNCTION(quickhash)
 
 PHP_RINIT_FUNCTION(quickhash)
 {
+	#if defined(COMPILE_DL_QUICKHASH) && defined(ZTS) && PHP_VERSION_ID >= 70000
+		ZEND_TSRMLS_CACHE_UPDATE();
+	#endif
 	return SUCCESS;
 }
 

--- a/quickhash.c
+++ b/quickhash.c
@@ -78,10 +78,14 @@ static void quickhash_init_globals(zend_quickhash_globals *quickhash_globals)
 
 zval *qh_instantiate(zend_class_entry *pce, zval *object TSRMLS_DC)
 {
+#if PHP_VERSION_ID < 70000
 	Z_TYPE_P(object) = IS_OBJECT;
+#endif
 	object_init_ex(object, pce);
+#if PHP_VERSION_ID < 70000
 	Z_SET_REFCOUNT_P(object, 1);
 	Z_UNSET_ISREF_P(object);
+#endif
 	return object;
 }
 

--- a/quickhash.c
+++ b/quickhash.c
@@ -59,9 +59,9 @@ zend_module_entry quickhash_module_entry = {
 
 
 #ifdef COMPILE_DL_QUICKHASH
-#if defined(ZTS) && PHP_VERSION_ID >= 70000
+# if defined(ZTS) && PHP_VERSION_ID >= 70000
 	ZEND_TSRMLS_CACHE_DEFINE();
-#endif
+# endif
 ZEND_GET_MODULE(quickhash)
 #endif
 
@@ -339,9 +339,9 @@ PHP_MSHUTDOWN_FUNCTION(quickhash)
 
 PHP_RINIT_FUNCTION(quickhash)
 {
-	#if defined(COMPILE_DL_QUICKHASH) && defined(ZTS) && PHP_VERSION_ID >= 70000
-		ZEND_TSRMLS_CACHE_UPDATE();
-	#endif
+#if defined(COMPILE_DL_QUICKHASH) && defined(ZTS) && PHP_VERSION_ID >= 70000
+	ZEND_TSRMLS_CACHE_UPDATE();
+#endif
 	return SUCCESS;
 }
 

--- a/quickhash.h
+++ b/quickhash.h
@@ -47,9 +47,13 @@
 #define QH_HASHER_MASK            0xFF00
 
 #if PHP_VERSION_ID < 70000
-#define QH_PHP_OBJ zend_object std; qhi* hash;
+# define QH_PHP_OBJ zend_object std; qhi* hash;
+# define ZEND_OBJECT_VALUE_PTR zend_object_value
+# define ZEND_OBJECT_PTR void*
 #else
-#define QH_PHP_OBJ qhi* hash; zend_object std;
+# define QH_PHP_OBJ qhi* hash; zend_object std;
+# define ZEND_OBJECT_VALUE_PTR zend_object*
+# define ZEND_OBJECT_PTR ZEND_OBJECT_VALUE_PTR
 #endif
 
 typedef struct _php_qh_string_context {

--- a/quickhash.h
+++ b/quickhash.h
@@ -46,6 +46,12 @@
 #define QH_HASHER_JENKINS2        0x0400
 #define QH_HASHER_MASK            0xFF00
 
+#if PHP_VERSION_ID < 70000
+#define QH_PHP_OBJ zend_object std; qhi* hash;
+#else
+#define QH_PHP_OBJ qhi* hash; zend_object std;
+#endif
+
 typedef struct _php_qh_string_context {
 	char     *string;
 	uint32_t  string_len;

--- a/quickhash.h
+++ b/quickhash.h
@@ -50,10 +50,12 @@
 # define QH_PHP_OBJ zend_object std; qhi* hash;
 # define ZEND_OBJECT_VALUE_PTR zend_object_value
 # define ZEND_OBJECT_PTR void*
+# define TYPE_ARG_L int
 #else
 # define QH_PHP_OBJ qhi* hash; zend_object std;
 # define ZEND_OBJECT_VALUE_PTR zend_object*
 # define ZEND_OBJECT_PTR ZEND_OBJECT_VALUE_PTR
+# define TYPE_ARG_L size_t
 #endif
 
 typedef struct _php_qh_string_context {

--- a/tests/int-hash-arrayaccess.phpt
+++ b/tests/int-hash-arrayaccess.phpt
@@ -30,7 +30,7 @@ bool(false)
 bool(false)
 bool(false)
 
-Warning: QuickHashIntHash::offsetGet() expects parameter 1 to be long, string given in %sint-hash-arrayaccess.php on line 13
+Warning: QuickHashIntHash::offsetGet() expects parameter 1 to be %s, string given in %sint-hash-arrayaccess.php on line 13
 bool(false)
 bool(false)
 int(-42)

--- a/tests/int-hash-from-file-failures.phpt
+++ b/tests/int-hash-from-file-failures.phpt
@@ -108,8 +108,8 @@ catch( Exception $e )
 Wrong params: 
 QuickHashIntHash::loadFromFile() expects at least 1 parameter, 0 given
 QuickHashIntHash::loadFromFile() expects at most 3 parameters, 4 given
-QuickHashIntHash::loadFromFile() expects parameter 3 to be long, string given
-QuickHashIntHash::loadFromFile() expects parameter 2 to be long, string given
+QuickHashIntHash::loadFromFile() expects parameter 3 to be %s, string given
+QuickHashIntHash::loadFromFile() expects parameter 2 to be %s, string given
 QuickHashIntHash::loadFromFile() expects parameter 1 to be string, object given
 
 Empty file: 

--- a/tests/int-hash-from-string-failures.phpt
+++ b/tests/int-hash-from-string-failures.phpt
@@ -61,13 +61,13 @@ catch( Exception $e )
 	echo $e->getMessage(), "\n";
 }
 ?>
---EXPECT--
+--EXPECTF--
 
 Wrong params: 
 QuickHashIntHash::loadFromString() expects at least 1 parameter, 0 given
 QuickHashIntHash::loadFromString() expects at most 3 parameters, 4 given
-QuickHashIntHash::loadFromString() expects parameter 3 to be long, string given
-QuickHashIntHash::loadFromString() expects parameter 2 to be long, string given
+QuickHashIntHash::loadFromString() expects parameter 3 to be %s, string given
+QuickHashIntHash::loadFromString() expects parameter 2 to be %s, string given
 QuickHashIntHash::loadFromString() expects parameter 1 to be string, object given
 
 Wrong size: 

--- a/tests/int-hash-update-failures.phpt
+++ b/tests/int-hash-update-failures.phpt
@@ -19,6 +19,6 @@ Warning: QuickHashIntHash::update() expects exactly 2 parameters, 1 given in %si
 
 Warning: QuickHashIntHash::update() expects exactly 2 parameters, 3 given in %sint-hash-update-failures.php on line 7
 
-Warning: QuickHashIntHash::update() expects parameter 1 to be long, string given in %sint-hash-update-failures.php on line 9
+Warning: QuickHashIntHash::update() expects parameter 1 to be %s, string given in %sint-hash-update-failures.php on line 9
 
-Warning: QuickHashIntHash::update() expects parameter 2 to be long, string given in %sint-hash-update-failures.php on line 10
+Warning: QuickHashIntHash::update() expects parameter 2 to be %s, string given in %sint-hash-update-failures.php on line 10

--- a/tests/int-set-delete-failures.phpt
+++ b/tests/int-set-delete-failures.phpt
@@ -18,4 +18,4 @@ Warning: QuickHashIntSet::delete() expects exactly 1 parameter, 0 given in %sint
 
 Warning: QuickHashIntSet::delete() expects exactly 1 parameter, 2 given in %sint-set-delete-failures.php on line 7
 
-Warning: QuickHashIntSet::delete() expects parameter 1 to be long, string given in %sint-set-delete-failures.php on line 9
+Warning: QuickHashIntSet::delete() expects parameter 1 to be %s, string given in %sint-set-delete-failures.php on line 9

--- a/tests/int-set-from-file-failures.phpt
+++ b/tests/int-set-from-file-failures.phpt
@@ -108,8 +108,8 @@ catch( Exception $e )
 Wrong params: 
 QuickHashIntSet::loadFromFile() expects at least 1 parameter, 0 given
 QuickHashIntSet::loadFromFile() expects at most 3 parameters, 4 given
-QuickHashIntSet::loadFromFile() expects parameter 3 to be long, string given
-QuickHashIntSet::loadFromFile() expects parameter 2 to be long, string given
+QuickHashIntSet::loadFromFile() expects parameter 3 to be %s, string given
+QuickHashIntSet::loadFromFile() expects parameter 2 to be %s, string given
 QuickHashIntSet::loadFromFile() expects parameter 1 to be string, object given
 
 Empty file: 

--- a/tests/int-set-from-string-failures.phpt
+++ b/tests/int-set-from-string-failures.phpt
@@ -61,13 +61,13 @@ catch( Exception $e )
 	echo $e->getMessage(), "\n";
 }
 ?>
---EXPECT--
+--EXPECTF--
 
 Wrong params: 
 QuickHashIntSet::loadFromString() expects at least 1 parameter, 0 given
 QuickHashIntSet::loadFromString() expects at most 3 parameters, 4 given
-QuickHashIntSet::loadFromString() expects parameter 3 to be long, string given
-QuickHashIntSet::loadFromString() expects parameter 2 to be long, string given
+QuickHashIntSet::loadFromString() expects parameter 3 to be %s, string given
+QuickHashIntSet::loadFromString() expects parameter 2 to be %s, string given
 QuickHashIntSet::loadFromString() expects parameter 1 to be string, object given
 
 Wrong size: 

--- a/tests/int-string-hash-arrayaccess.phpt
+++ b/tests/int-string-hash-arrayaccess.phpt
@@ -30,7 +30,7 @@ bool(false)
 bool(false)
 bool(false)
 
-Warning: QuickHashIntStringHash::offsetGet() expects parameter 1 to be long, string given in %sint-string-hash-arrayaccess.php on line 13
+Warning: QuickHashIntStringHash::offsetGet() expects parameter 1 to be %s, string given in %sint-string-hash-arrayaccess.php on line 13
 bool(false)
 bool(false)
 string(16) "minus fourty two"

--- a/tests/int-string-hash-from-file-failures.phpt
+++ b/tests/int-string-hash-from-file-failures.phpt
@@ -108,8 +108,8 @@ catch( Exception $e )
 Wrong params: 
 QuickHashIntStringHash::loadFromFile() expects at least 1 parameter, 0 given
 QuickHashIntStringHash::loadFromFile() expects at most 3 parameters, 4 given
-QuickHashIntStringHash::loadFromFile() expects parameter 3 to be long, string given
-QuickHashIntStringHash::loadFromFile() expects parameter 2 to be long, string given
+QuickHashIntStringHash::loadFromFile() expects parameter 3 to be %s, string given
+QuickHashIntStringHash::loadFromFile() expects parameter 2 to be %s, string given
 QuickHashIntStringHash::loadFromFile() expects parameter 1 to be string, object given
 
 Empty file: 

--- a/tests/int-string-hash-from-string-failures.phpt
+++ b/tests/int-string-hash-from-string-failures.phpt
@@ -61,13 +61,13 @@ catch( Exception $e )
 	echo $e->getMessage(), "\n";
 }
 ?>
---EXPECT--
+--EXPECTF--
 
 Wrong params: 
 QuickHashIntStringHash::loadFromString() expects at least 1 parameter, 0 given
 QuickHashIntStringHash::loadFromString() expects at most 3 parameters, 4 given
-QuickHashIntStringHash::loadFromString() expects parameter 3 to be long, string given
-QuickHashIntStringHash::loadFromString() expects parameter 2 to be long, string given
+QuickHashIntStringHash::loadFromString() expects parameter 3 to be %s, string given
+QuickHashIntStringHash::loadFromString() expects parameter 2 to be %s, string given
 QuickHashIntStringHash::loadFromString() expects parameter 1 to be string, object given
 
 Wrong size: 

--- a/tests/int-string-hash-update-failures.phpt
+++ b/tests/int-string-hash-update-failures.phpt
@@ -19,6 +19,6 @@ Warning: QuickHashIntStringHash::update() expects exactly 2 parameters, 1 given 
 
 Warning: QuickHashIntStringHash::update() expects exactly 2 parameters, 3 given in %sint-string-hash-update-failures.php on line 7
 
-Warning: QuickHashIntStringHash::update() expects parameter 1 to be long, string given in %sint-string-hash-update-failures.php on line 9
+Warning: QuickHashIntStringHash::update() expects parameter 1 to be %s, string given in %sint-string-hash-update-failures.php on line 9
 
 Warning: QuickHashIntStringHash::update() expects parameter 2 to be string, object given in %sint-string-hash-update-failures.php on line 10

--- a/tests/string-int-hash-from-file-failures.phpt
+++ b/tests/string-int-hash-from-file-failures.phpt
@@ -108,8 +108,8 @@ catch( Exception $e )
 Wrong params: 
 QuickHashStringIntHash::loadFromFile() expects at least 1 parameter, 0 given
 QuickHashStringIntHash::loadFromFile() expects at most 3 parameters, 4 given
-QuickHashStringIntHash::loadFromFile() expects parameter 3 to be long, string given
-QuickHashStringIntHash::loadFromFile() expects parameter 2 to be long, string given
+QuickHashStringIntHash::loadFromFile() expects parameter 3 to be %s, string given
+QuickHashStringIntHash::loadFromFile() expects parameter 2 to be %s, string given
 QuickHashStringIntHash::loadFromFile() expects parameter 1 to be string, object given
 
 Empty file: 

--- a/tests/string-int-hash-from-string-failures.phpt
+++ b/tests/string-int-hash-from-string-failures.phpt
@@ -61,13 +61,13 @@ catch( Exception $e )
 	echo $e->getMessage(), "\n";
 }
 ?>
---EXPECT--
+--EXPECTF--
 
 Wrong params: 
 QuickHashStringIntHash::loadFromString() expects at least 1 parameter, 0 given
 QuickHashStringIntHash::loadFromString() expects at most 3 parameters, 4 given
-QuickHashStringIntHash::loadFromString() expects parameter 3 to be long, string given
-QuickHashStringIntHash::loadFromString() expects parameter 2 to be long, string given
+QuickHashStringIntHash::loadFromString() expects parameter 3 to be %s, string given
+QuickHashStringIntHash::loadFromString() expects parameter 2 to be %s, string given
 QuickHashStringIntHash::loadFromString() expects parameter 1 to be string, object given
 
 Wrong size: 

--- a/tests/string-int-hash-update-failures.phpt
+++ b/tests/string-int-hash-update-failures.phpt
@@ -18,4 +18,4 @@ Warning: QuickHashStringIntHash::update() expects exactly 2 parameters, 1 given 
 
 Warning: QuickHashStringIntHash::update() expects exactly 2 parameters, 3 given in %sstring-int-hash-update-failures.php on line 7
 
-Warning: QuickHashStringIntHash::update() expects parameter 2 to be long, object given in %sstring-int-hash-update-failures.php on line 9
+Warning: QuickHashStringIntHash::update() expects parameter 2 to be %s, object given in %sstring-int-hash-update-failures.php on line 9


### PR DESCRIPTION
PHP5.5 and PHP7 support for Quickhash - updated previous pull request. All tests pass on PHP5.5 and PHP7.

The only thing not clear how to fix:

I had to add include php.h, zend.h, zend_API.h to quickhash.h, hash-algorithms.h, this is because otherwise stdint.h, ... are not included because of not defined constants